### PR TITLE
Fix three high-priority audit findings + upgrade to mlx-lm-lora 3.0.0 (FTPO, SFT loss types)

### DIFF
--- a/backend/app/schemas/export.py
+++ b/backend/app/schemas/export.py
@@ -1,6 +1,11 @@
-from typing import Literal
+from typing import Annotated, Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+# Contract (docs/api.md): a plain file name under exports_dir — letters,
+# digits, `.`, `_`, `-`; no path separators (`/`, `\`) or `..`; must not
+# start with `.` or `-`. Anything else is a 422 validation_error.
+ExportName = Annotated[str, Field(pattern=r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")]
 
 
 class FuseRequest(BaseModel):
@@ -8,13 +13,13 @@ class FuseRequest(BaseModel):
     model_id: str | None = None
     adapter_path: str | None = None
     de_quantize: bool = False
-    output_name: str
+    output_name: ExportName
 
 
 class GGUFRequest(BaseModel):
     model_path: str
     outtype: Literal["f16", "q8_0"]
-    output_name: str
+    output_name: ExportName
 
 
 class PreflightCheck(BaseModel):
@@ -31,7 +36,7 @@ class PreflightReport(BaseModel):
 class OllamaModelfileRequest(BaseModel):
     gguf_path: str
     model_family: Literal["qwen", "llama", "smollm", "mistral", "custom"]
-    name: str
+    name: ExportName
     custom_template: str | None = None
 
 

--- a/backend/app/services/export_service.py
+++ b/backend/app/services/export_service.py
@@ -97,6 +97,22 @@ class ExportService:
                 message="Eğitim işi çalışırken export yapılamaz (Metal bellek çakışması)"
             )
 
+    def _export_output_path(self, file_name: str) -> Path:
+        """Join `file_name` onto exports_dir, refusing anything that escapes it.
+
+        Defense in depth: the schemas already reject path separators and `..`,
+        but no caller of this service may write outside exports_dir even if
+        that validation is bypassed.
+        """
+        candidate = self._settings.exports_dir / file_name
+        base = self._settings.exports_dir.resolve()
+        resolved = candidate.resolve()
+        if resolved == base or not resolved.is_relative_to(base):
+            raise ValidationAppError(
+                message=f"geçersiz çıktı adı (exports dizini dışına çıkıyor): {file_name}"
+            )
+        return candidate
+
     def _llama_cpp_dir(self) -> Path | None:
         candidates = []
         if self._settings.llama_cpp_dir is not None:
@@ -134,13 +150,13 @@ class ExportService:
     ) -> dict:
         await self._assert_training_inactive(conn)
         model_path, adapter_path, source_run_id = await self._resolve_fuse_source(conn, body)
+        save_path = self._export_output_path(body.output_name)
 
         export_id = f"ex_{uuid.uuid4().hex[:12]}"
         created_at = _now()
         await ExportsRepo(conn).insert(export_id, "fuse", "running", created_at)
         self._progress_logs[export_id] = []
 
-        save_path = self._settings.exports_dir / body.output_name
         argv = [
             sys.executable,
             "-m",
@@ -242,13 +258,13 @@ class ExportService:
 
         llama_dir = self._llama_cpp_dir()
         assert llama_dir is not None  # guaranteed by the passing preflight above
+        output_path = self._export_output_path(f"{body.output_name}.gguf")
 
         export_id = f"ex_{uuid.uuid4().hex[:12]}"
         created_at = _now()
         await ExportsRepo(conn).insert(export_id, "gguf", "running", created_at)
         self._progress_logs[export_id] = []
 
-        output_path = self._settings.exports_dir / f"{body.output_name}.gguf"
         argv = [
             sys.executable,
             str(llama_dir / "convert_hf_to_gguf.py"),
@@ -331,7 +347,7 @@ class ExportService:
             context["custom_template"] = body.custom_template
         rendered = template.render(**context)
 
-        output_dir = self._settings.exports_dir / body.name
+        output_dir = self._export_output_path(body.name)
         output_dir.mkdir(parents=True, exist_ok=True)
         output_path = output_dir / "Modelfile"
         output_path.write_text(rendered)

--- a/backend/tests/integration/test_export_api.py
+++ b/backend/tests/integration/test_export_api.py
@@ -136,6 +136,62 @@ async def test_fuse_validation_error_shape(client, export_service):
     assert response.json()["error"]["code"] == "validation_error"
 
 
+# --------------------- output_name / name validation ------------------------
+
+BAD_EXPORT_NAMES = [
+    "../../evil",  # traversal
+    "..",  # bare traversal component
+    "/abs/path",  # absolute path
+    "a/b",  # path separator
+    "a\\b",  # backslash
+    ".hidden",  # leading dot
+    "-dash",  # leading dash
+    "",  # empty
+    "a b",  # whitespace
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_name", BAD_EXPORT_NAMES)
+async def test_fuse_rejects_unsafe_output_name(client, export_service, bad_name):
+    service, subprocess = export_service
+    response = await client.post(
+        "/api/v1/export/fuse",
+        json={
+            "model_id": "mlx-community/Foo-4bit",
+            "adapter_path": "/abs/adapters",
+            "output_name": bad_name,
+        },
+    )
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "validation_error"
+    assert subprocess.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_name", BAD_EXPORT_NAMES)
+async def test_gguf_rejects_unsafe_output_name(client, export_service, bad_name):
+    service, subprocess = export_service
+    response = await client.post(
+        "/api/v1/export/gguf",
+        json={"model_path": "/abs/fused", "outtype": "f16", "output_name": bad_name},
+    )
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "validation_error"
+    assert subprocess.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_name", BAD_EXPORT_NAMES)
+async def test_ollama_modelfile_rejects_unsafe_name(client, export_service, bad_name):
+    response = await client.post(
+        "/api/v1/export/ollama-modelfile",
+        json={"gguf_path": "/abs/model.gguf", "model_family": "qwen", "name": bad_name},
+    )
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "validation_error"
+
+
 # ------------------------------- gguf --------------------------------------
 
 

--- a/backend/tests/unit/test_export_service.py
+++ b/backend/tests/unit/test_export_service.py
@@ -568,6 +568,79 @@ async def test_modelfile_registers_artifact(settings, conn):
     assert artifacts[0]["path"] == str(settings.exports_dir / "my-model" / "Modelfile")
 
 
+# --------------------- exports_dir escape (defense in depth) ----------------
+#
+# The schemas reject these names at the API boundary; `model_construct`
+# bypasses pydantic validation to prove the service itself refuses to write
+# outside exports_dir.
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_name", ["../../evil", "/abs/path", "nested/../../evil", ".."])
+async def test_fuse_refuses_output_name_escaping_exports_dir(settings, conn, bad_name):
+    subprocess = RecordingSubprocess()
+    service = ExportService(settings, run_subprocess=subprocess)
+    body = FuseRequest.model_construct(
+        run_id=None,
+        model_id="mlx-community/Foo-4bit",
+        adapter_path="/abs/adapters",
+        de_quantize=False,
+        output_name=bad_name,
+    )
+
+    with pytest.raises(ValidationAppError):
+        await service.start_fuse(conn, body, BackgroundTasks())
+    assert subprocess.calls == []
+
+
+@pytest.mark.asyncio
+async def test_gguf_refuses_output_name_escaping_exports_dir(settings, conn):
+    llama_dir = settings.cache_dir / "llama.cpp"
+    llama_dir.mkdir(parents=True, exist_ok=True)
+    (llama_dir / "convert_hf_to_gguf.py").write_text("# stub")
+    model_path = _make_model_dir(settings, "mlx-community/Foo", {"model_type": "llama"})
+
+    subprocess = RecordingSubprocess()
+    service = ExportService(settings, run_subprocess=subprocess)
+    body = GGUFRequest.model_construct(
+        model_path=str(model_path), outtype="f16", output_name="../../evil"
+    )
+
+    with pytest.raises(ValidationAppError):
+        await service.start_gguf(conn, body, BackgroundTasks())
+    assert subprocess.calls == []
+
+
+@pytest.mark.asyncio
+async def test_modelfile_refuses_name_escaping_exports_dir(settings, conn):
+    service = ExportService(settings, run_subprocess=RecordingSubprocess())
+    body = OllamaModelfileRequest.model_construct(
+        gguf_path="/abs/model.gguf", model_family="qwen", name="../../evil", custom_template=None
+    )
+
+    with pytest.raises(ValidationAppError):
+        await service.render_modelfile(conn, body)
+    assert not (settings.exports_dir.parent / "evil").exists()
+
+
+@pytest.mark.asyncio
+async def test_export_names_with_dots_and_dashes_still_work(settings, conn):
+    subprocess = RecordingSubprocess()
+    service = ExportService(settings, run_subprocess=subprocess)
+    body = FuseRequest(
+        model_id="mlx-community/Foo-4bit",
+        adapter_path="/abs/adapters",
+        output_name="My_Model.v1-final",
+    )
+
+    bg = BackgroundTasks()
+    await service.start_fuse(conn, body, bg)
+    await bg()
+
+    argv = subprocess.calls[0]
+    assert argv[argv.index("--save-path") + 1] == str(settings.exports_dir / "My_Model.v1-final")
+
+
 # --------------------------------- misc -----------------------------------
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -259,6 +259,11 @@ Any stdout line that is not valid JSON with an `event` key is treated as a raw l
 While a training job is queued/running, `POST /export/fuse` and `POST /export/gguf`
 return `409 training_active` (Metal memory contention).
 
+`output_name` (fuse, gguf) and `name` (ollama-modelfile) must be a plain file name:
+`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$` — letters, digits, `.`, `_`, `-`; no path
+separators (`/`, `\`) or `..`; must not start with `.` or `-`. Anything else →
+`422 validation_error`.
+
 ### POST /export/fuse
 `{"run_id": "run_..."} | {"model_id": "...", "adapter_path": "..."}` + `{"de_quantize": false, "output_name": "my-model"}`
 → `202 {"export_id": "ex_...", "kind": "fuse"}`

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { Route, BrowserRouter, Routes } from 'react-router-dom'
+import { ErrorBoundary } from './components/common/ErrorBoundary'
 import { AppLayout } from './components/layout/AppLayout'
 import { DashboardPage } from './pages/DashboardPage'
 import { ModelsPage } from './pages/ModelsPage'
@@ -35,7 +36,9 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
-        <AppRoutes />
+        <ErrorBoundary>
+          <AppRoutes />
+        </ErrorBoundary>
       </BrowserRouter>
     </QueryClientProvider>
   )

--- a/frontend/src/components/arena/useArenaSocket.ts
+++ b/frontend/src/components/arena/useArenaSocket.ts
@@ -3,6 +3,8 @@ import { ReconnectingWS } from '../../api/ws'
 import type { ArenaWsClientFrame, ArenaWsServerFrame } from '../../api/types'
 import { useArenaStore } from './arenaStore'
 
+const CONNECTION_LOST_MESSAGE = 'Connection lost'
+
 export interface UseArenaSocketOptions {
   /** code === 'training_active' (a whole-turn, side: null error) */
   onTrainingActive?: (message: string) => void
@@ -19,6 +21,8 @@ export interface UseArenaSocketResult {
   cancel: () => void
   /** True from the moment `generate` is sent until the `done` frame arrives. */
   isGenerating: boolean
+  /** False while the socket is down and ReconnectingWS is retrying. */
+  isConnected: boolean
 }
 
 /**
@@ -31,12 +35,34 @@ export function useArenaSocket(options: UseArenaSocketOptions = {}): UseArenaSoc
   const { onTrainingActive, onError, WebSocketImpl } = options
 
   const socketRef = useRef<ReconnectingWS<ArenaWsServerFrame> | null>(null)
+  const generatingRef = useRef(false)
   const [isGenerating, setIsGenerating] = useState(false)
+  // Starts true so the "reconnecting" UI only appears after an actual close
+  // (including a failed initial connect), not during the first handshake.
+  const [isConnected, setIsConnected] = useState(true)
 
   useEffect(() => {
     const socket = new ReconnectingWS<ArenaWsServerFrame>({
       path: '/api/v1/ws/arena',
       WebSocketImpl,
+      onOpen: () => {
+        setIsConnected(true)
+      },
+      onClose: () => {
+        setIsConnected(false)
+        // A drop mid-turn kills the in-flight generation server-side: mark
+        // whichever sides were still pending as errored so the user can retry.
+        if (!generatingRef.current) return
+        generatingRef.current = false
+        setIsGenerating(false)
+        const store = useArenaStore.getState()
+        if (store.sideA.status === 'waiting' || store.sideA.status === 'streaming') {
+          store.setSideError('a', CONNECTION_LOST_MESSAGE)
+        }
+        if (store.sideB.status === 'waiting' || store.sideB.status === 'streaming') {
+          store.setSideError('b', CONNECTION_LOST_MESSAGE)
+        }
+      },
       onFrame: (frame) => {
         const store = useArenaStore.getState()
         switch (frame.type) {
@@ -55,6 +81,7 @@ export function useArenaSocket(options: UseArenaSocketOptions = {}): UseArenaSoc
               break
             }
             store.resetPending()
+            generatingRef.current = false
             setIsGenerating(false)
             if (frame.code === 'training_active') {
               onTrainingActive?.(frame.message)
@@ -64,6 +91,7 @@ export function useArenaSocket(options: UseArenaSocketOptions = {}): UseArenaSoc
             break
           }
           case 'done':
+            generatingRef.current = false
             setIsGenerating(false)
             break
         }
@@ -79,6 +107,7 @@ export function useArenaSocket(options: UseArenaSocketOptions = {}): UseArenaSoc
   }, [])
 
   const sendGenerate = useCallback((frame: Extract<ArenaWsClientFrame, { type: 'generate' }>) => {
+    generatingRef.current = true
     setIsGenerating(true)
     socketRef.current?.send(frame)
   }, [])
@@ -87,5 +116,5 @@ export function useArenaSocket(options: UseArenaSocketOptions = {}): UseArenaSoc
     socketRef.current?.send({ type: 'cancel' })
   }, [])
 
-  return { sendGenerate, cancel, isGenerating }
+  return { sendGenerate, cancel, isGenerating, isConnected }
 }

--- a/frontend/src/components/chat/useChatSocket.ts
+++ b/frontend/src/components/chat/useChatSocket.ts
@@ -8,6 +8,8 @@ interface QueueItem {
   frame: ChatWsClientFrame
 }
 
+const CONNECTION_LOST_MESSAGE = 'Connection lost'
+
 export interface UseChatSocketOptions {
   /** code === 'training_active' */
   onTrainingActive?: (message: string) => void
@@ -27,6 +29,8 @@ export interface UseChatSocketResult {
   cancelActive: () => void
   /** sessionId of the generation currently streaming, or null if idle. */
   activeSessionId: string | null
+  /** False while the socket is down and ReconnectingWS is retrying. */
+  isConnected: boolean
 }
 
 /**
@@ -43,6 +47,9 @@ export function useChatSocket(options: UseChatSocketOptions = {}): UseChatSocket
   const activeSessionRef = useRef<string | null>(null)
   const connectedRef = useRef(false)
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null)
+  // Starts true so the "reconnecting" UI only appears after an actual close
+  // (including a failed initial connect), not during the first handshake.
+  const [isConnected, setIsConnected] = useState(true)
 
   const dispatchNext = useCallback(() => {
     if (activeSessionRef.current) return
@@ -60,10 +67,20 @@ export function useChatSocket(options: UseChatSocketOptions = {}): UseChatSocket
       WebSocketImpl,
       onOpen: () => {
         connectedRef.current = true
+        setIsConnected(true)
         dispatchNext()
       },
       onClose: () => {
         connectedRef.current = false
+        setIsConnected(false)
+        // A drop mid-stream kills the in-flight generation server-side: mark
+        // the session errored so the user can retry, and clear the active slot
+        // so dispatchNext can resume the queue after the socket reconnects.
+        if (activeSessionRef.current) {
+          useChatStore.getState().setError(activeSessionRef.current, CONNECTION_LOST_MESSAGE)
+          activeSessionRef.current = null
+          setActiveSessionId(null)
+        }
       },
       onFrame: (frame) => {
         const store = useChatStore.getState()
@@ -128,5 +145,5 @@ export function useChatSocket(options: UseChatSocketOptions = {}): UseChatSocket
     socketRef.current?.send({ type: 'cancel' })
   }, [])
 
-  return { enqueueGenerate, cancelActive, activeSessionId }
+  return { enqueueGenerate, cancelActive, activeSessionId, isConnected }
 }

--- a/frontend/src/components/common/ErrorBoundary.test.tsx
+++ b/frontend/src/components/common/ErrorBoundary.test.tsx
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ErrorBoundary } from './ErrorBoundary'
+
+function Bomb({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) {
+    throw new Error('boom')
+  }
+  return <p>recovered content</p>
+}
+
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    // React logs caught render errors via console.error; keep test output clean.
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders children when nothing throws', () => {
+    render(
+      <ErrorBoundary>
+        <p>safe content</p>
+      </ErrorBoundary>,
+    )
+
+    expect(screen.getByText('safe content')).toBeInTheDocument()
+  })
+
+  it('renders the fallback with the error message when a child throws', () => {
+    render(
+      <ErrorBoundary>
+        <Bomb shouldThrow={true} />
+      </ErrorBoundary>,
+    )
+
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+    expect(screen.getByText('boom')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Reload' })).toBeInTheDocument()
+  })
+
+  it('recovers via "Try again" once the child no longer throws', async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(
+      <ErrorBoundary>
+        <Bomb shouldThrow={true} />
+      </ErrorBoundary>,
+    )
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+
+    rerender(
+      <ErrorBoundary>
+        <Bomb shouldThrow={false} />
+      </ErrorBoundary>,
+    )
+    await user.click(screen.getByRole('button', { name: 'Try again' }))
+
+    expect(screen.getByText('recovered content')).toBeInTheDocument()
+    expect(screen.queryByText('Something went wrong')).not.toBeInTheDocument()
+  })
+
+  it('resets when resetKey changes', () => {
+    const { rerender } = render(
+      <ErrorBoundary resetKey="/train">
+        <Bomb shouldThrow={true} />
+      </ErrorBoundary>,
+    )
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+
+    rerender(
+      <ErrorBoundary resetKey="/models">
+        <Bomb shouldThrow={false} />
+      </ErrorBoundary>,
+    )
+
+    expect(screen.getByText('recovered content')).toBeInTheDocument()
+    expect(screen.queryByText('Something went wrong')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/common/ErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary.tsx
@@ -1,0 +1,71 @@
+import { Component } from 'react'
+import type { ErrorInfo, ReactNode } from 'react'
+import { Button } from './Button'
+
+interface ErrorBoundaryProps {
+  children: ReactNode
+  /** When this value changes (e.g. on navigation), a captured error is cleared. */
+  resetKey?: unknown
+}
+
+interface ErrorBoundaryState {
+  error: Error | null
+  prevResetKey: unknown
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null, prevResetKey: this.props.resetKey }
+
+  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
+    return { error }
+  }
+
+  static getDerivedStateFromProps(
+    props: ErrorBoundaryProps,
+    state: ErrorBoundaryState,
+  ): Partial<ErrorBoundaryState> | null {
+    if (props.resetKey !== state.prevResetKey) {
+      return { error: null, prevResetKey: props.resetKey }
+    }
+    return null
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('ErrorBoundary caught an error:', error, info.componentStack)
+  }
+
+  handleReset = () => {
+    this.setState({ error: null })
+  }
+
+  handleReload = () => {
+    window.location.reload()
+  }
+
+  render() {
+    const { error } = this.state
+    if (error === null) {
+      return this.props.children
+    }
+
+    return (
+      <div
+        role="alert"
+        className="flex flex-1 flex-col items-center justify-center gap-3 p-12 text-center"
+      >
+        <h2 className="text-sm font-semibold text-text">Something went wrong</h2>
+        <p className="max-w-md break-words font-mono text-sm text-danger">
+          {error.message || String(error)}
+        </p>
+        <div className="mt-2 flex items-center gap-2">
+          <Button variant="secondary" size="sm" onClick={this.handleReset}>
+            Try again
+          </Button>
+          <Button variant="primary" size="sm" onClick={this.handleReload}>
+            Reload
+          </Button>
+        </div>
+      </div>
+    )
+  }
+}

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -1,16 +1,20 @@
-import { Outlet } from 'react-router-dom'
+import { Outlet, useLocation } from 'react-router-dom'
+import { ErrorBoundary } from '../common/ErrorBoundary'
 import { SideNav } from './SideNav'
 import { TopBar } from './TopBar'
 import { StatusFooter } from './StatusFooter'
 
 export function AppLayout() {
+  const location = useLocation()
   return (
     <div className="flex h-screen flex-col bg-bg text-text">
       <TopBar />
       <div className="flex flex-1 overflow-hidden">
         <SideNav />
         <main className="flex flex-1 flex-col overflow-hidden">
-          <Outlet />
+          <ErrorBoundary resetKey={location.pathname}>
+            <Outlet />
+          </ErrorBoundary>
         </main>
       </div>
       <StatusFooter />

--- a/frontend/src/pages/ArenaPage.test.tsx
+++ b/frontend/src/pages/ArenaPage.test.tsx
@@ -188,6 +188,50 @@ describe('ArenaPage', () => {
     expect(socket.sentFrames[1]).toEqual({ type: 'cancel' })
   })
 
+  it('marks active sides as errored and recovers after a reconnect when the socket drops mid-generation', async () => {
+    const { user, socket } = await renderReady()
+
+    await user.type(screen.getByLabelText('Message'), 'Hi{Enter}')
+    await waitFor(() => expect(socket.sentFrames).toHaveLength(1))
+
+    act(() => socket.emit({ type: 'side_start', side: 'a' }))
+    act(() => socket.emit({ type: 'token', side: 'a', text: 'Par' }))
+
+    act(() => socket.close())
+
+    // streaming side a and still-waiting side b are both errored
+    const columnA = screen.getByTestId('arena-column-a')
+    const columnB = screen.getByTestId('arena-column-b')
+    expect(within(columnA).getByRole('alert')).toHaveTextContent('Connection lost')
+    expect(within(columnB).getByRole('alert')).toHaveTextContent('Connection lost')
+    // the partial stream is kept as a message
+    expect(within(columnA).getByText('Par')).toBeInTheDocument()
+
+    // isGenerating resets so the user can retry, and the banner shows
+    expect(screen.getByRole('button', { name: 'Send' })).toBeInTheDocument()
+    expect(screen.getByTestId('ws-reconnecting-banner')).toBeInTheDocument()
+
+    // ReconnectingWS retries with backoff and opens a fresh socket
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(2), { timeout: 3000 })
+    const reconnected = MockWebSocket.instances[1]
+    act(() => reconnected.open())
+    expect(screen.queryByTestId('ws-reconnecting-banner')).not.toBeInTheDocument()
+
+    // a retry goes out over the new socket
+    await user.type(screen.getByLabelText('Message'), 'Retry{Enter}')
+    await waitFor(() => expect(reconnected.sentFrames).toHaveLength(1))
+    expect(reconnected.sentFrames[0]).toMatchObject({ type: 'generate' })
+  })
+
+  it('a disconnect while idle does not mark any side as errored', async () => {
+    const { socket } = await renderReady()
+
+    act(() => socket.close())
+
+    expect(screen.getByTestId('ws-reconnecting-banner')).toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
   it('shows the training_active banner without closing the socket', async () => {
     const { user, socket } = await renderReady()
 

--- a/frontend/src/pages/ArenaPage.tsx
+++ b/frontend/src/pages/ArenaPage.tsx
@@ -114,6 +114,16 @@ export function ArenaPage() {
         </div>
       )}
 
+      {!arenaSocket.isConnected && (
+        <div
+          data-testid="ws-reconnecting-banner"
+          role="status"
+          className="rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-sm text-amber-400"
+        >
+          Connection lost — reconnecting…
+        </div>
+      )}
+
       <div className="flex items-center justify-end">
         <Button variant="secondary" size="sm" onClick={handleClear} disabled={isGenerating}>
           Clear

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -239,6 +239,65 @@ describe('ChatPage', () => {
     expect(within(baseColumn).getByText('base-says-hi')).toBeInTheDocument()
   })
 
+  it('marks the in-flight message as errored and recovers after a reconnect when the socket drops mid-stream', async () => {
+    const { user, socket } = await renderReady()
+
+    await user.type(screen.getByLabelText('Message'), 'Hi{Enter}')
+    await waitFor(() => expect(socket.sentFrames).toHaveLength(1))
+    act(() => socket.emit({ type: 'token', text: 'Par' }))
+
+    act(() => socket.close())
+
+    // in-flight session errored + generating flag cleared so the user can retry
+    expect(screen.getByRole('alert')).toHaveTextContent('Connection lost')
+    expect(screen.getByRole('button', { name: 'Send' })).toBeInTheDocument()
+    expect(screen.getByTestId('ws-reconnecting-banner')).toBeInTheDocument()
+
+    // ReconnectingWS retries with backoff and opens a fresh socket
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(2), { timeout: 3000 })
+    const reconnected = MockWebSocket.instances[1]
+    act(() => reconnected.open())
+    expect(screen.queryByTestId('ws-reconnecting-banner')).not.toBeInTheDocument()
+
+    // the queue is not blocked by the dead generation — a retry goes out
+    await user.type(screen.getByLabelText('Message'), 'Retry{Enter}')
+    await waitFor(() => expect(reconnected.sentFrames).toHaveLength(1))
+    expect(reconnected.sentFrames[0]).toMatchObject({
+      type: 'generate',
+      messages: [{ role: 'user', content: 'Hi' }, { role: 'user', content: 'Retry' }],
+    })
+  })
+
+  it('compare mode: resumes the queued base generate after reconnect when the socket drops mid-adapter-stream', async () => {
+    const { user, socket } = await renderReady()
+
+    await user.selectOptions(screen.getByLabelText('Adapter'), 'smol-lora-v1')
+    await user.click(screen.getByRole('switch', { name: 'Compare with/without adapter' }))
+    await user.type(screen.getByLabelText('Message'), 'Hi{Enter}')
+    await waitFor(() => expect(socket.sentFrames).toHaveLength(1))
+
+    act(() => socket.emit({ type: 'token', text: 'partial' }))
+    act(() => socket.close())
+
+    // only the in-flight adapter column is errored; the base half stays queued
+    const adapterColumn = screen.getByTestId(ADAPTER_COLUMN_TESTID)
+    const baseColumn = screen.getByTestId(BASE_COLUMN_TESTID)
+    expect(within(adapterColumn).getByRole('alert')).toHaveTextContent('Connection lost')
+    expect(within(baseColumn).queryByRole('alert')).not.toBeInTheDocument()
+
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(2), { timeout: 3000 })
+    const reconnected = MockWebSocket.instances[1]
+    act(() => reconnected.open())
+
+    // reopening dispatches the queued base generate without user action
+    await waitFor(() => expect(reconnected.sentFrames).toHaveLength(1))
+    expect(reconnected.sentFrames[0]).toMatchObject({
+      type: 'generate',
+      adapter_path: null,
+      messages: [{ role: 'user', content: 'Hi' }],
+    })
+  })
+
   it('includes prior turns as history in subsequent generate frames', async () => {
     const { user, socket } = await renderReady()
 

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -142,6 +142,16 @@ export function ChatPage() {
         </div>
       )}
 
+      {!chatSocket.isConnected && (
+        <div
+          data-testid="ws-reconnecting-banner"
+          role="status"
+          className="rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-sm text-amber-400"
+        >
+          Connection lost — reconnecting…
+        </div>
+      )}
+
       <div className="flex items-center justify-end">
         <Button variant="secondary" size="sm" onClick={handleClear} disabled={isSending}>
           Clear conversation


### PR DESCRIPTION
Fixes the three high-priority issues from the repository audit, and upgrades the training engine to mlx-lm-lora 3.0.0 with its new capabilities wired end to end.

Closes #1, closes #2, closes #3.

## #1 — Chat & Arena: WebSocket disconnect recovery (`ea5f248`)

- `useChatSocket.onClose` now marks the in-flight session as errored (`Connection lost`) via the existing `chatStore.setError`, and clears the active-session slot so `dispatchNext()` can resume the queue after `ReconnectingWS` reopens (queued compare-mode turns are kept and dispatched on reconnect).
- `useArenaSocket` gains the missing `onClose` handler: any side still `waiting`/`streaming` is errored via `arenaStore.setSideError` (partial streamed text is preserved) and `isGenerating` resets.
- Both hooks expose `isConnected`; ChatPage and ArenaPage show a "Connection lost — reconnecting…" banner while the socket is down.
- 4 new page tests cover mid-stream drop → error + retry, compare-mode queue resume, partial-text preservation, idle disconnect.

## #2 — Global + route-level error boundaries (`d114eb2`)

- New `components/common/ErrorBoundary.tsx` with "Try again" and "Reload" actions.
- Top-level boundary around `<AppRoutes />`; a second boundary around the route `<Outlet />` in `AppLayout` with `resetKey={location.pathname}`, so a crashing page keeps the nav usable and navigating away auto-recovers. 4 new tests.

## #3 — Export API path traversal (`55b374f` docs, `59c3e08` code)

- Contract-first: `docs/api.md` updated in its own commit — `output_name` (fuse, gguf) and `name` (ollama-modelfile) must match `^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`; violations → `422 validation_error`.
- Schema fields enforce the pattern; previously `../../foo` or an absolute path escaped `exports_dir` and could write anywhere.
- Defense in depth: the service resolves the joined path and verifies `is_relative_to(exports_dir)` before writing. 27 new backend tests.

## mlx-lm-lora 2.1.0 → 3.0.0 (`955818e`, `70b7a10`, `b0e0fef`, `f64d65b`)

Verified against both source trees: the worker's bridge surface (`train.run(args, training_callback)`, `build_parser()`, `CONFIG_DEFAULTS`, callback dict keys) is unchanged in v3, and the removed synthetic-dataset generators were never used here. `mlx-lm` stays pinned at 0.31.3 (v3 needs ≥0.30.6). Lock diff touches only mlx-lm-lora and a transitive dep v3 dropped.

New v3 capabilities, contract-first (`docs/api.md` updated in its own commit):

- **FTPO train mode** (final-token preference optimization) end to end: `TrainMode.FTPO` with optional `lambda_mse_target` / `tau_mse_target` / `lambda_mse` / `clip_epsilon_logits` (forwarded only when set, so library defaults 0.05/1.0/0.4/2.0 survive), new `DatasetFormat.FTPO` with structural row validation (`context_with_chat_template` / `rejected_decoded` / `multi_chosen_decoded`), the `ftpo↔ftpo` mode-format compatibility rule, and the form card with the four optional inputs.
- **SFT loss selection**: new sft-only `sft_loss_type` field (`nll | chunked_nll | dft` — DFT dynamically de-weights tokens the model already predicts confidently) with an "SFT loss" select in the form; null → library default `nll`.
- Conditional 422 validation: `sft_loss_type` rejected on non-sft modes, ftpo params rejected on non-ftpo modes; the form nulls mode-specific fields on mode switch so it can't trip them.
- Also drops the stale "Faz 1 only opens sft in the UI" contract note (all modes have been exposed since 830c8f7).

## Verification

- `make test`: backend **375 passed**, frontend **193 passed** (baseline was 320/179; none broken)
- `make lint`: `ruff check` clean, `tsc --noEmit` clean; `oxlint` byte-identical to baseline

> Note: real-model e2e (`make e2e`) needs Apple Silicon and can't run in this environment — the v3 bridge was verified by source inspection plus the injected-fake-module worker tests. Worth a quick local smoke run before relying on FTPO/DFT for a real training.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UEysgYYG512HSnoKf5cgm