### PR TITLE
Reap stale running downloads/imports/exports/recipe jobs on startup

### DIFF
--- a/backend/app/db/repositories.py
+++ b/backend/app/db/repositories.py
@@ -325,6 +325,15 @@ class DownloadsRepo:
         )
         await self._conn.commit()
 
+    async def fail_stale_running(self, finished_at: str, error: str) -> int:
+        cursor = await self._conn.execute(
+            "UPDATE downloads SET status = 'failed', finished_at = ?, error = ? "
+            "WHERE status = 'running'",
+            (finished_at, error),
+        )
+        await self._conn.commit()
+        return cursor.rowcount
+
     async def get(self, download_id: str) -> dict | None:
         self._conn.row_factory = aiosqlite.Row
         cursor = await self._conn.execute(
@@ -391,6 +400,15 @@ class ExportsRepo:
         )
         await self._conn.commit()
 
+    async def fail_stale_running(self, finished_at: str, error: str) -> int:
+        cursor = await self._conn.execute(
+            "UPDATE exports SET status = 'failed', finished_at = ?, error = ? "
+            "WHERE status = 'running'",
+            (finished_at, error),
+        )
+        await self._conn.commit()
+        return cursor.rowcount
+
     async def get(self, export_id: str) -> dict | None:
         self._conn.row_factory = aiosqlite.Row
         cursor = await self._conn.execute(
@@ -435,6 +453,15 @@ class RecipeJobsRepo:
             (status, rows_emitted, preview_json, dataset_id, error, id),
         )
         await self._conn.commit()
+
+    async def fail_stale_running(self, error: str) -> int:
+        # recipe_jobs has no finished_at column.
+        cursor = await self._conn.execute(
+            "UPDATE recipe_jobs SET status = 'failed', error = ? WHERE status = 'running'",
+            (error,),
+        )
+        await self._conn.commit()
+        return cursor.rowcount
 
     async def get(self, id: str) -> dict | None:
         self._conn.row_factory = aiosqlite.Row
@@ -493,6 +520,15 @@ class DatasetImportsRepo:
             (status, dataset_id, error, finished_at, id),
         )
         await self._conn.commit()
+
+    async def fail_stale_running(self, finished_at: str, error: str) -> int:
+        cursor = await self._conn.execute(
+            "UPDATE dataset_imports SET status = 'failed', finished_at = ?, error = ? "
+            "WHERE status = 'running'",
+            (finished_at, error),
+        )
+        await self._conn.commit()
+        return cursor.rowcount
 
     async def get(self, id: str) -> dict | None:
         self._conn.row_factory = aiosqlite.Row

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -23,15 +24,32 @@ ALLOWED_ORIGINS = ["http://localhost:5173"]
 
 
 async def reap_orphans() -> None:
-    """Reap orphaned training/export subprocesses left over from a previous run.
+    """Reap orphaned background work left over from a previous run.
 
-    Wave-1 T1: delegates to `JobManager.reap_orphans()`, which scans `runs`
+    Training runs: delegates to `JobManager.reap_orphans()`, which scans `runs`
     for rows still marked `queued`/`running` whose `pid` is no longer alive
     (-> `failed`) or is still alive (-> killpg + `cancelled`).
+
+    Downloads, dataset imports, exports and recipe jobs run as in-process
+    asyncio/background tasks that never survive a restart, so any row still
+    `running` at startup is unrecoverable. Mark them `failed` — otherwise the
+    `get_active_*` duplicate guards keep returning `409 conflict` for the same
+    model/dataset forever.
     """
+    from app.db.database import get_connection
+    from app.db.repositories import DatasetImportsRepo, DownloadsRepo, ExportsRepo, RecipeJobsRepo
     from app.training.manager import get_job_manager
 
     await get_job_manager().reap_orphans()
+
+    error = "interrupted by server restart"
+    finished_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+    settings = get_settings()
+    async with get_connection(settings.db_path) as conn:
+        await DownloadsRepo(conn).fail_stale_running(finished_at, error)
+        await DatasetImportsRepo(conn).fail_stale_running(finished_at, error)
+        await ExportsRepo(conn).fail_stale_running(finished_at, error)
+        await RecipeJobsRepo(conn).fail_stale_running(error)
 
 
 @asynccontextmanager

--- a/backend/tests/unit/test_startup_reap.py
+++ b/backend/tests/unit/test_startup_reap.py
@@ -1,0 +1,77 @@
+"""Startup reaping of background-job rows stranded `running` by a restart.
+
+Downloads, dataset imports, exports and recipe jobs run as in-process tasks
+that never survive a restart; `app.main.reap_orphans` must mark their stale
+`running` rows `failed` so the `get_active_*` duplicate guards stop returning
+409 for the same model/dataset forever.
+"""
+
+import aiosqlite
+import pytest
+
+from app.config import get_settings
+from app.db.database import init_db
+from app.db.repositories import (
+    DatasetImportsRepo,
+    DownloadsRepo,
+    ExportsRepo,
+    RecipeJobsRepo,
+)
+from app.training import manager as manager_module
+
+TS = "2026-07-14T00:00:00.000Z"
+
+
+async def _seed_stale_rows(db_path) -> None:
+    async with aiosqlite.connect(db_path) as conn:
+        downloads = DownloadsRepo(conn)
+        await downloads.insert("dl_stale", "mlx-community/Tiny-1", "running", 1, 2, 1, 2, TS)
+        await downloads.insert("dl_done", "mlx-community/Tiny-2", "running", 2, 2, 2, 2, TS)
+        await downloads.finish("dl_done", "completed", TS)
+        await DatasetImportsRepo(conn).insert(
+            "imp_stale", "org/some-data", None, "train", "some-data", None, "running", TS
+        )
+        await ExportsRepo(conn).insert("exp_stale", "fuse", "running", TS)
+        await RecipeJobsRepo(conn).insert("rcp_stale", "doc-to-dataset", "running", TS)
+
+
+@pytest.mark.asyncio
+async def test_reap_orphans_fails_stale_background_jobs(data_dir):
+    from app.main import reap_orphans
+
+    settings = get_settings()
+    await init_db(settings.db_path)
+    await _seed_stale_rows(settings.db_path)
+
+    manager_module.reset_job_manager()
+    await reap_orphans()
+
+    async with aiosqlite.connect(settings.db_path) as conn:
+        downloads = DownloadsRepo(conn)
+        stale_download = await downloads.get("dl_stale")
+        assert stale_download["status"] == "failed"
+        assert stale_download["error"] == "interrupted by server restart"
+        assert stale_download["finished_at"] is not None
+
+        # Terminal rows are untouched.
+        done_download = await downloads.get("dl_done")
+        assert done_download["status"] == "completed"
+        assert done_download["error"] is None
+
+        stale_import = await DatasetImportsRepo(conn).get("imp_stale")
+        assert stale_import["status"] == "failed"
+        assert stale_import["error"] == "interrupted by server restart"
+
+        stale_export = await ExportsRepo(conn).get("exp_stale")
+        assert stale_export["status"] == "failed"
+        assert stale_export["error"] == "interrupted by server restart"
+
+        stale_recipe = await RecipeJobsRepo(conn).get("rcp_stale")
+        assert stale_recipe["status"] == "failed"
+        assert stale_recipe["error"] == "interrupted by server restart"
+
+        # The duplicate guards that previously produced permanent 409s are clear.
+        assert await downloads.get_active_by_model("mlx-community/Tiny-1") is None
+        assert (
+            await DatasetImportsRepo(conn).get_active_by_hf_id("org/some-data") is None
+        )

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -125,6 +125,11 @@ affect the contract.
    `worker.pid` as a fallback) is still alive: if so, it's terminated (TERM
    then, after a short poll, KILL if still alive) and marked `cancelled`; if
    not, the row is marked `failed` with an explanatory message.
+   The same startup hook also fails any `downloads` / `dataset_imports` /
+   `exports` / `recipe_jobs` row still `running`: those run as in-process
+   asyncio/background tasks that never survive a restart, and a stale
+   `running` row would otherwise make the `get_active_*` duplicate guards
+   return `409 conflict` for that model/dataset forever.
 
 ## WS protocols summary
 


### PR DESCRIPTION
Closes #5.

(This commit was pushed to the #19 branch a few minutes after #19 merged, so it never landed on main — rebased onto current main and re-opened here as its own PR.)

## Problem

Downloads, dataset imports, exports and recipe jobs run as in-process asyncio/background tasks that never survive a restart, but their DB rows stayed `status='running'` after a crash. Because the `get_active_*` duplicate guards match on that status, `POST /models/download` and `POST /datasets/import` returned `409 conflict` for the same model/dataset **permanently**, and `GET /export/jobs/{id}` reported a forever-`running` export — only manual DB editing cleared it.

## Fix

The startup reap in `app/main.py` (previously covering only the `runs` table via `JobManager.reap_orphans()`) now also marks any `downloads` / `dataset_imports` / `exports` / `recipe_jobs` row still `running` as `failed` with "interrupted by server restart", via new `fail_stale_running` methods on the four repo classes. `docs/architecture.md`'s orphan-reaping section documents the extended behavior (no API-contract change — this is internal startup behavior).

## Tests

New `backend/tests/unit/test_startup_reap.py`: seeds stale `running` rows in all four tables plus a completed download, runs the startup reap, and asserts the stale rows are `failed` with the explanatory error, terminal rows are untouched, and the 409-producing duplicate guards (`get_active_by_model` / `get_active_by_hf_id`) are clear.

## Verification

- `cd backend && uv run pytest`: **376 passed** (re-run after rebasing onto current main)
- `uv run ruff check .`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UEysgYYG512HSnoKf5cgm

---
_Generated by [Claude Code](https://claude.ai/code/session_014UEysgYYG512HSnoKf5cgm)_