### PR TITLE
Backend robustness: five small verified fixes (issue #8)

### DIFF
--- a/backend/app/api/arena.py
+++ b/backend/app/api/arena.py
@@ -1,6 +1,7 @@
 # Faz-2 T17: side-by-side model arena WS (docs/api.md "Arena" section).
 
 import asyncio
+import logging
 from collections.abc import Callable
 from typing import Annotated
 
@@ -14,6 +15,8 @@ from app.deps import get_current_user, get_db, get_settings
 from app.schemas.arena import ArenaGenerateFrame
 from app.services.arena_service import ArenaService
 from app.services.inference_service import get_inference_service
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(dependencies=[Depends(get_current_user)])
 
@@ -46,10 +49,13 @@ async def ws_arena(
                 register_cancel=_register_cancel,
             ):
                 await websocket.send_json(out_frame)
-        except Exception as exc:  # noqa: BLE001 - forwarded to client as an error frame
+        except Exception:  # noqa: BLE001 - reported to the client as a generic error frame
+            # Log the real exception server-side; never leak its text
+            # (filesystem paths etc.) to the client.
+            logger.exception("unexpected error during arena turn")
             try:
                 await websocket.send_json(
-                    {"type": "error", "side": None, "code": "internal", "message": str(exc)}
+                    {"type": "error", "side": None, "code": "internal", "message": "internal error"}
                 )
             except Exception:
                 pass

--- a/backend/app/api/inference.py
+++ b/backend/app/api/inference.py
@@ -1,6 +1,7 @@
 # Wave-1 T4: chat inference (mlx_lm generate loop) ve adapter listeleme.
 
 import asyncio
+import logging
 import threading
 from pathlib import Path
 from typing import Annotated
@@ -10,20 +11,19 @@ from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
 from pydantic import BaseModel, ValidationError
 
 from app.config import Settings
+from app.core.paths import model_dirname
 from app.db.repositories import RunsRepo
 from app.deps import get_current_user, get_db, get_settings
 from app.schemas.inference import AdapterInfo, ChatGenerateFrame
 from app.services.inference_service import get_inference_service
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(dependencies=[Depends(get_current_user)])
 
 
 class AdaptersListResponse(BaseModel):
     adapters: list[AdapterInfo]
-
-
-def _model_dir_name(model_id: str) -> str:
-    return model_id.replace("/", "__", 1)
 
 
 @router.get("/adapters", response_model=AdaptersListResponse)
@@ -67,7 +67,7 @@ async def ws_chat(
     async def _run_generation(frame: ChatGenerateFrame, cancel_event: threading.Event) -> None:
         nonlocal generating
         try:
-            model_dir = settings.models_dir / _model_dir_name(frame.model_id)
+            model_dir = settings.models_dir / model_dirname(frame.model_id)
             if not model_dir.exists():
                 await websocket.send_json(
                     {
@@ -107,10 +107,13 @@ async def ws_chat(
                 cancel_event=cancel_event,
             ):
                 await websocket.send_json(out_frame)
-        except Exception as exc:  # noqa: BLE001 - forwarded to client as an error frame
+        except Exception:  # noqa: BLE001 - reported to the client as a generic error frame
+            # Log the real exception server-side; never leak its text
+            # (filesystem paths etc.) to the client.
+            logger.exception("unexpected error during chat generation")
             try:
                 await websocket.send_json(
-                    {"type": "error", "code": "internal", "message": str(exc)}
+                    {"type": "error", "code": "internal", "message": "internal error"}
                 )
             except Exception:
                 pass

--- a/backend/app/api/training.py
+++ b/backend/app/api/training.py
@@ -100,6 +100,45 @@ async def _watch_for_disconnect(websocket: WebSocket) -> None:
         return
 
 
+class _BackfillBuffer:
+    """Topic subscriber standing in for the raw websocket while the persisted
+    metric backfill is being read and sent.
+
+    Subscribing only AFTER reading the backfill loses any metric that is
+    persisted-and-broadcast in between; subscribing BEFORE means live frames
+    can overlap the backfill. So the socket subscribes this buffer first:
+    frames broadcast during the backfill window are queued, then `drain`
+    forwards them — dropping metric frames the backfill already covered —
+    and switches to direct passthrough for all later broadcasts.
+    """
+
+    def __init__(self, websocket: WebSocket) -> None:
+        self._websocket = websocket
+        self._queue: list[dict] = []
+        self._live = False
+
+    async def send_json(self, message: dict) -> None:
+        if self._live:
+            await self._websocket.send_json(message)
+        else:
+            self._queue.append(message)
+
+    async def drain(self, sent_metric_keys: set[tuple[str, int]], last_step: int) -> None:
+        while self._queue:
+            message = self._queue.pop(0)
+            if message.get("type") == "metric":
+                data = message.get("data") or {}
+                step = data.get("step")
+                if (data.get("kind"), step) in sent_metric_keys:
+                    continue  # already sent in the backfill
+                if isinstance(step, int) and step <= last_step:
+                    continue  # client already had it before reconnecting
+            await self._websocket.send_json(message)
+        # No awaits between the empty-queue check and going live, so no frame
+        # can slip into the queue and be stranded.
+        self._live = True
+
+
 @router.websocket("/ws/train/{run_id}")
 async def ws_train(
     websocket: WebSocket,
@@ -120,39 +159,49 @@ async def ws_train(
         except (TypeError, ValueError):
             last_step = 0
 
-    try:
-        run = await manager.get_run(run_id)
-    except NotFoundError:
-        await websocket.close(code=1008, reason="run not found")
-        return
-
-    metrics = await manager.get_metrics(run_id, after_step=last_step)
-    for metric in metrics:
-        await websocket.send_json({"type": "metric", "data": metric.model_dump()})
-
-    await websocket.send_json(
-        {"type": "status", "status": run.status.value, "error": run.error}
-    )
-
-    if run.status in TERMINAL_STATUSES:
-        await websocket.close()
-        return
-
     ws_manager = get_ws_manager()
     topic = f"train/{run_id}"
-    await ws_manager.subscribe(topic, websocket)
+    buffer = _BackfillBuffer(websocket)
+    # Subscribe BEFORE reading run state + persisted metrics: a metric
+    # persisted-and-broadcast between the two would otherwise never reach
+    # this client. Overlap is de-duplicated in `drain`.
+    await ws_manager.subscribe(topic, buffer)
 
-    disconnect_task = asyncio.create_task(_watch_for_disconnect(websocket))
-    done_task = asyncio.create_task(manager.done_event(run_id).wait())
     try:
-        await asyncio.wait(
-            {disconnect_task, done_task}, return_when=asyncio.FIRST_COMPLETED
+        try:
+            run = await manager.get_run(run_id)
+        except NotFoundError:
+            await websocket.close(code=1008, reason="run not found")
+            return
+
+        metrics = await manager.get_metrics(run_id, after_step=last_step)
+        sent_metric_keys: set[tuple[str, int]] = set()
+        for metric in metrics:
+            await websocket.send_json({"type": "metric", "data": metric.model_dump()})
+            sent_metric_keys.add((metric.kind, metric.step))
+
+        await websocket.send_json(
+            {"type": "status", "status": run.status.value, "error": run.error}
         )
+
+        if run.status in TERMINAL_STATUSES:
+            await websocket.close()
+            return
+
+        await buffer.drain(sent_metric_keys, last_step)
+
+        disconnect_task = asyncio.create_task(_watch_for_disconnect(websocket))
+        done_task = asyncio.create_task(manager.done_event(run_id).wait())
+        try:
+            await asyncio.wait(
+                {disconnect_task, done_task}, return_when=asyncio.FIRST_COMPLETED
+            )
+        finally:
+            for task in (disconnect_task, done_task):
+                if not task.done():
+                    task.cancel()
     finally:
-        for task in (disconnect_task, done_task):
-            if not task.done():
-                task.cancel()
-        await ws_manager.unsubscribe(topic, websocket)
+        await ws_manager.unsubscribe(topic, buffer)
 
     try:
         await websocket.close()

--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -1,7 +1,11 @@
+import logging
+
 from fastapi import FastAPI, Request
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
 
 
 class AppError(Exception):
@@ -74,7 +78,14 @@ def register_exception_handlers(app: FastAPI) -> None:
 
     @app.exception_handler(Exception)
     async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+        # Log the real exception server-side; the client only gets a generic
+        # message so internal details (filesystem paths etc.) never leak.
+        logger.exception(
+            "unhandled exception while handling %s %s", request.method, request.url.path
+        )
         return JSONResponse(
             status_code=500,
-            content={"error": {"code": "internal", "message": str(exc), "detail": {}}},
+            content={
+                "error": {"code": "internal", "message": "internal server error", "detail": {}}
+            },
         )

--- a/backend/app/core/paths.py
+++ b/backend/app/core/paths.py
@@ -1,0 +1,35 @@
+"""Canonical mapping between HF model ids and on-disk directory names.
+
+The model registry (`app/services/model_registry.py`) writes model
+directories on download, so its historical mapping is the de-facto on-disk
+format. Every component that resolves a `model_id` to a directory under
+`MLXLF_DATA_DIR/models/` MUST use these helpers so ids keep resolving to
+the directories that already exist on users' disks.
+
+Semantics (do not change — existing data depends on it):
+- `org/name`  -> `org__name` (only the FIRST slash is replaced; an id with
+  more than one slash, e.g. `org/a/b`, maps to `org__a/b`).
+- `name` (no slash) -> `_name` (leading underscore marks "no org").
+- Inverse: `org__name` -> `org/name` (split on the FIRST `__`); a dirname
+  without `__` is returned unchanged (so `_name` does not round-trip back
+  to `name` — the registry has always behaved this way).
+"""
+
+from __future__ import annotations
+
+
+def model_dirname(model_id: str) -> str:
+    """Directory name under `models_dir` for a Hugging Face model id."""
+    org, _, name = model_id.partition("/")
+    if not name:
+        # No "/" in model_id — fall back to using the whole string as the name.
+        return f"_{org}"
+    return f"{org}__{name}"
+
+
+def model_id_from_dirname(dirname: str) -> str:
+    """Reconstruct the model id from a directory name written by `model_dirname`."""
+    org, sep, name = dirname.partition("__")
+    if not sep:
+        return dirname
+    return f"{org}/{name}"

--- a/backend/app/db/repositories.py
+++ b/backend/app/db/repositories.py
@@ -521,6 +521,30 @@ class DatasetImportsRepo:
         )
         await self._conn.commit()
 
+    async def finish_if_active(
+        self,
+        id: str,
+        status: str,
+        dataset_id: str | None,
+        error: str | None,
+        finished_at: str,
+    ) -> bool:
+        """`finish`, but refuses to overwrite a row already in a terminal
+        status (completed/failed/cancelled). Returns True if the row was
+        updated. Guards the import-cancel race: last-writer-wins double
+        finishes could otherwise flip e.g. a cancelled import back to
+        completed."""
+        cursor = await self._conn.execute(
+            """
+            UPDATE dataset_imports
+            SET status = ?, dataset_id = ?, error = ?, finished_at = ?
+            WHERE id = ? AND status NOT IN ('completed', 'failed', 'cancelled')
+            """,
+            (status, dataset_id, error, finished_at, id),
+        )
+        await self._conn.commit()
+        return cursor.rowcount > 0
+
     async def fail_stale_running(self, finished_at: str, error: str) -> int:
         cursor = await self._conn.execute(
             "UPDATE dataset_imports SET status = 'failed', finished_at = ?, error = ? "

--- a/backend/app/services/arena_service.py
+++ b/backend/app/services/arena_service.py
@@ -10,18 +10,18 @@ there is only one Metal GPU to share.
 
 from __future__ import annotations
 
+import logging
 import threading
 from collections.abc import AsyncIterator, Callable
 from pathlib import Path
 
 from app.config import Settings
+from app.core.paths import model_dirname
 from app.db.repositories import RunsRepo
 from app.schemas.arena import ArenaGenerateFrame
 from app.services.inference_service import InferenceService
 
-
-def _model_dir_name(model_id: str) -> str:
-    return model_id.replace("/", "__", 1)
+logger = logging.getLogger(__name__)
 
 
 class ArenaService:
@@ -74,7 +74,7 @@ class ArenaService:
                 worker_event = threading.Event()
                 current_worker_event = worker_event
 
-                model_dir = settings.models_dir / _model_dir_name(spec.model_id)
+                model_dir = settings.models_dir / model_dirname(spec.model_id)
                 if not model_dir.exists():
                     yield {
                         "type": "error",
@@ -105,8 +105,16 @@ class ArenaService:
                             yield {"type": "token", "side": side, "text": out["text"]}
                         elif out["type"] == "done":
                             yield {"type": "side_done", "side": side, "usage": out["usage"]}
-                except Exception as exc:  # noqa: BLE001 - forwarded as a per-side error frame
-                    yield {"type": "error", "side": side, "code": "internal", "message": str(exc)}
+                except Exception:  # noqa: BLE001 - reported as a generic per-side error frame
+                    # Log the real exception server-side; never leak its text
+                    # (filesystem paths etc.) to the client.
+                    logger.exception("unexpected error while generating arena side %r", side)
+                    yield {
+                        "type": "error",
+                        "side": side,
+                        "code": "internal",
+                        "message": "internal error",
+                    }
 
                 if turn_cancelled.is_set():
                     break

--- a/backend/app/services/dataset_import_service.py
+++ b/backend/app/services/dataset_import_service.py
@@ -215,7 +215,9 @@ class DatasetImportService:
                 stream = await asyncio.to_thread(_load_dataset_stream, hf_dataset_id, config, split)
                 iterator = iter(stream)
             except Exception as exc:
-                await repo.finish(import_id, "failed", None, f"dataset yüklenemedi: {exc}", _now())
+                await repo.finish_if_active(
+                    import_id, "failed", None, f"dataset yüklenemedi: {exc}", _now()
+                )
                 self._cleanup(import_id)
                 return
 
@@ -231,7 +233,7 @@ class DatasetImportService:
                         try:
                             line = json.dumps(row, ensure_ascii=False)
                         except TypeError:
-                            await repo.finish(
+                            await repo.finish_if_active(
                                 import_id,
                                 "failed",
                                 None,
@@ -248,18 +250,23 @@ class DatasetImportService:
                         if max_rows is not None and count >= max_rows:
                             break
             except Exception as exc:
-                await repo.finish(import_id, "failed", None, str(exc), _now())
+                await repo.finish_if_active(import_id, "failed", None, str(exc), _now())
                 self._cleanup(import_id)
                 return
 
             if cancel_event.is_set():
+                # The worker (this coroutine) is the single owner of the
+                # terminal DB write and the temp-dir cleanup on cancellation;
+                # `cancel_import` only sets the event.
                 await repo.update_progress(import_id, count)
-                await repo.finish(import_id, "cancelled", None, None, _now())
+                await repo.finish_if_active(import_id, "cancelled", None, None, _now())
                 self._cleanup(import_id)
                 return
 
             if count == 0:
-                await repo.finish(import_id, "failed", None, "dataset'ten hiç satır okunamadı", _now())
+                await repo.finish_if_active(
+                    import_id, "failed", None, "dataset'ten hiç satır okunamadı", _now()
+                )
                 self._cleanup(import_id)
                 return
 
@@ -272,12 +279,14 @@ class DatasetImportService:
             except ValidationAppError as exc:
                 keys = _first_row_keys(output_path)
                 keys_msg = f" (bulunan kolon adları: {', '.join(keys)})" if keys else ""
-                await repo.finish(import_id, "failed", None, f"{exc.message}{keys_msg}", _now())
+                await repo.finish_if_active(
+                    import_id, "failed", None, f"{exc.message}{keys_msg}", _now()
+                )
                 self._cleanup(import_id)
                 return
 
             await repo.update_progress(import_id, count)
-            await repo.finish(import_id, "completed", dataset_info.dataset_id, None, _now())
+            await repo.finish_if_active(import_id, "completed", dataset_info.dataset_id, None, _now())
             self._cleanup(import_id)
         finally:
             await conn.close()
@@ -320,11 +329,22 @@ class DatasetImportService:
 
         event = self._cancel_events.get(import_id)
         if event is not None:
+            # A live worker in this process owns the terminal DB write and the
+            # temp-dir cleanup (see `_run_job`) — writing/cleaning here would
+            # race its in-flight writes to `output.jsonl` and its own
+            # `finish(...)` (a user-cancelled import could flip back to
+            # `completed`, or the writer could crash when its directory
+            # disappears under it). Only signal it and report current state;
+            # the row flips to `cancelled` once the worker observes the event.
             event.set()
-
-        finished_at = _now()
-        await repo.finish(import_id, "cancelled", None, None, finished_at)
-        shutil.rmtree(self._job_dir(import_id), ignore_errors=True)
+        else:
+            # No live worker in this process (e.g. a `running` row left over
+            # from a previous process, or the event was already dropped) — the
+            # cancel would otherwise never terminalize, so finalize here.
+            # `finish_if_active` guards the race where the worker terminalized
+            # the row between our status check above and this write.
+            await repo.finish_if_active(import_id, "cancelled", None, None, _now())
+            self._cleanup(import_id)
 
         updated = await repo.get(import_id)
         assert updated is not None

--- a/backend/app/services/export_service.py
+++ b/backend/app/services/export_service.py
@@ -23,6 +23,7 @@ from jinja2 import Environment, FileSystemLoader
 
 from app.config import Settings, get_settings
 from app.core.errors import NotFoundError, TrainingActiveError, ValidationAppError
+from app.core.paths import model_dirname
 from app.db.repositories import ArtifactsRepo, ExportsRepo, RunsRepo
 from app.schemas.export import (
     ExportArtifact,
@@ -86,9 +87,7 @@ class ExportService:
         return conn
 
     def _model_path_for_id(self, model_id: str) -> Path:
-        org, sep, name = model_id.partition("/")
-        dirname = f"{org}__{name}" if sep else org
-        return self._settings.models_dir / dirname
+        return self._settings.models_dir / model_dirname(model_id)
 
     async def _assert_training_inactive(self, conn: aiosqlite.Connection) -> None:
         active = await RunsRepo(conn).list_active()
@@ -202,12 +201,28 @@ class ExportService:
             )
 
         config_path = Path(model_path) / "config.json"
+        config: dict[str, Any] | None = None
         if not config_path.is_file():
             message = f"config.json bulunamadı: {config_path}"
+        else:
+            try:
+                parsed = json.loads(config_path.read_text())
+            except (OSError, UnicodeDecodeError, ValueError) as exc:
+                # ValueError covers json.JSONDecodeError.
+                message = f"config.json is not valid JSON: {exc}"
+            else:
+                if isinstance(parsed, dict):
+                    config = parsed
+                else:
+                    message = (
+                        "config.json is not valid JSON: expected a JSON object, "
+                        f"got {type(parsed).__name__}"
+                    )
+
+        if config is None:
             checks.append(PreflightCheck(name="arch_supported", ok=False, message=message))
             checks.append(PreflightCheck(name="weights_dequantized", ok=False, message=message))
         else:
-            config = json.loads(config_path.read_text())
             model_type = config.get("model_type")
             if model_type in CURATED_ARCHS:
                 checks.append(

--- a/backend/app/services/model_registry.py
+++ b/backend/app/services/model_registry.py
@@ -26,27 +26,13 @@ from tqdm import tqdm
 
 from app.config import Settings
 from app.core.errors import ConflictError, InternalError, NotFoundError, TrainingActiveError
+from app.core.paths import model_dirname, model_id_from_dirname
 from app.db.database import get_connection
 from app.db.repositories import DownloadsRepo, RunsRepo
 from app.schemas.models import DownloadInfo, HFSearchResult, ModelInfo, Quantization
 
 # Minimum interval between DB progress snapshots for a single in-flight download.
 _PERSIST_INTERVAL_SECONDS = 0.5
-
-
-def _dirname_for_model_id(model_id: str) -> str:
-    org, _, name = model_id.partition("/")
-    if not name:
-        # No "/" in model_id — fall back to using the whole string as the name.
-        return f"_{org}"
-    return f"{org}__{name}"
-
-
-def _model_id_for_dirname(dirname: str) -> str:
-    org, sep, name = dirname.partition("__")
-    if not sep:
-        return dirname
-    return f"{org}/{name}"
 
 
 def _now_iso() -> str:
@@ -148,7 +134,7 @@ class ModelRegistry:
 
         stat = model_dir.stat()
         return ModelInfo(
-            model_id=_model_id_for_dirname(model_dir.name),
+            model_id=model_id_from_dirname(model_dir.name),
             path=str(model_dir.resolve()),
             size_bytes=self._dir_size_bytes(model_dir),
             model_type=model_type,
@@ -176,7 +162,7 @@ class ModelRegistry:
         return {m.model_id for m in await self.list_local_models()}
 
     def _local_model_dir(self, model_id: str) -> Path:
-        return self._settings.models_dir / _dirname_for_model_id(model_id)
+        return self._settings.models_dir / model_dirname(model_id)
 
     # ------------------------------------------------------------------ #
     # HF Hub search

--- a/backend/app/training/manager.py
+++ b/backend/app/training/manager.py
@@ -27,6 +27,7 @@ from pathlib import Path
 
 from app.config import Settings, get_settings
 from app.core.errors import NotFoundError, TrainingActiveError, ValidationAppError
+from app.core.paths import model_dirname
 from app.core.process import (
     is_pid_alive,
     kill_process_group,
@@ -114,7 +115,7 @@ class JobManager:
     # ------------------------------------------------------------------
 
     async def create_job(self, config: TrainingConfig) -> RunSummary:
-        model_dir = self._settings.models_dir / config.model_id.replace("/", "__")
+        model_dir = self._settings.models_dir / model_dirname(config.model_id)
         if not model_dir.is_dir():
             raise NotFoundError(f"model '{config.model_id}' not found")
 

--- a/backend/app/training/worker.py
+++ b/backend/app/training/worker.py
@@ -96,12 +96,13 @@ def _build_worker_args(run_dir: Path, config, train_mod=None):
     import types
 
     from app.config import get_settings
+    from app.core.paths import model_dirname
 
     if train_mod is None:
         train_mod = _import_mlx_train_module()
 
     settings = get_settings()
-    model_path = str(settings.models_dir / config.model_id.replace("/", "__"))
+    model_path = str(settings.models_dir / model_dirname(config.model_id))
     dataset_data_dir = str(settings.datasets_dir / config.dataset_id / "data")
     adapter_path = str(run_dir / "adapters")
 

--- a/backend/tests/integration/test_arena_api.py
+++ b/backend/tests/integration/test_arena_api.py
@@ -16,9 +16,9 @@ import pytest
 from starlette.testclient import TestClient
 
 from app.config import get_settings
+from app.core.paths import model_dirname
 from app.main import create_app
 from app.services import inference_service as svc
-from app.services.arena_service import _model_dir_name
 
 MODEL_A = "mlx-community/SmolLM-135M-Instruct-4bit"
 MODEL_B = "mlx-community/Qwen2.5-0.5B-Instruct-4bit"
@@ -102,7 +102,7 @@ def _drain_until_done(ws) -> list[dict]:
 
 def _mkdirs(settings, *model_ids: str) -> None:
     for model_id in model_ids:
-        (settings.models_dir / _model_dir_name(model_id)).mkdir(parents=True, exist_ok=True)
+        (settings.models_dir / model_dirname(model_id)).mkdir(parents=True, exist_ok=True)
 
 
 def test_happy_path_frame_order(data_dir, patched_mlx):

--- a/backend/tests/integration/test_dataset_import_api.py
+++ b/backend/tests/integration/test_dataset_import_api.py
@@ -192,9 +192,17 @@ async def test_cancel_import_then_double_cancel_and_unknown_id(client, monkeypat
     match = await _poll_import_by_hf_id(client, "mlx-community/cancel-me")
     import_id = match["import_id"]
 
+    # The worker owns the terminal write: cancel only signals it, so the row
+    # is still `running` while the (paused) worker hasn't observed the event.
     cancel_response = await client.post(f"/api/v1/datasets/imports/{import_id}/cancel")
     assert cancel_response.status_code == 202
-    assert cancel_response.json()["status"] == "cancelled"
+    assert cancel_response.json()["status"] == "running"
+
+    resume_event.set()
+    await import_task
+
+    match = await _poll_import_by_hf_id(client, "mlx-community/cancel-me")
+    assert match["status"] == "cancelled"
 
     second_cancel = await client.post(f"/api/v1/datasets/imports/{import_id}/cancel")
     assert second_cancel.status_code == 409
@@ -203,9 +211,6 @@ async def test_cancel_import_then_double_cancel_and_unknown_id(client, monkeypat
     unknown_cancel = await client.post("/api/v1/datasets/imports/di_does_not_exist/cancel")
     assert unknown_cancel.status_code == 404
     assert unknown_cancel.json()["error"]["code"] == "not_found"
-
-    resume_event.set()
-    await import_task
 
     datasets_resp = await client.get("/api/v1/datasets")
     names = [d["name"] for d in datasets_resp.json()["datasets"]]

--- a/backend/tests/integration/test_error_shape.py
+++ b/backend/tests/integration/test_error_shape.py
@@ -1,4 +1,5 @@
 import pytest
+from httpx import ASGITransport, AsyncClient
 
 
 @pytest.mark.asyncio
@@ -16,6 +17,9 @@ async def test_app_error_returns_contract_error_shape(client):
     data = response.json()
     assert data["error"]["code"] == "not_found"
     assert "message" in data["error"]
+    # Typed AppErrors keep their real, useful message (unlike unexpected
+    # exceptions, which are made generic — see the 500 test below).
+    assert "ex_does_not_exist" in data["error"]["message"]
 
 
 @pytest.mark.asyncio
@@ -32,3 +36,24 @@ async def test_train_jobs_validation_error_has_standard_shape(client):
     assert response.status_code == 422
     data = response.json()
     assert data["error"]["code"] == "validation_error"
+
+
+@pytest.mark.asyncio
+async def test_unexpected_exception_returns_generic_500_without_leaking_detail(app):
+    secret = "RuntimeError-with-secret-path-/home/someone/.ssh/id_rsa"
+
+    async def _boom():
+        raise RuntimeError(secret)
+
+    app.router.add_api_route("/api/v1/_test/boom", _boom, methods=["GET"])
+
+    # Starlette re-raises the exception after sending the 500 response, so the
+    # ASGI test transport must be told not to propagate it into the test.
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.get("/api/v1/_test/boom")
+
+    assert response.status_code == 500
+    data = response.json()
+    assert data["error"] == {"code": "internal", "message": "internal server error", "detail": {}}
+    assert secret not in response.text

--- a/backend/tests/integration/test_export_api.py
+++ b/backend/tests/integration/test_export_api.py
@@ -241,6 +241,48 @@ async def test_gguf_start_422_on_failing_preflight(client, export_service, data_
 
 
 @pytest.mark.asyncio
+async def test_gguf_preflight_corrupt_config_returns_ok_false_not_500(
+    client, export_service, data_dir
+):
+    settings = get_settings()
+    llama_dir = settings.cache_dir / "llama.cpp"
+    llama_dir.mkdir(parents=True, exist_ok=True)
+    (llama_dir / "convert_hf_to_gguf.py").write_text("# stub")
+    model_dir = settings.models_dir / "corrupt__model"
+    model_dir.mkdir(parents=True, exist_ok=True)
+    (model_dir / "config.json").write_text("{not valid json")
+
+    response = await client.get(
+        "/api/v1/export/gguf/preflight", params={"model_path": str(model_dir)}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is False
+    failing = [c for c in data["checks"] if not c["ok"]]
+    assert any("config.json is not valid JSON" in c["message"] for c in failing)
+
+
+@pytest.mark.asyncio
+async def test_gguf_start_corrupt_config_is_422_not_500(client, export_service, data_dir):
+    settings = get_settings()
+    llama_dir = settings.cache_dir / "llama.cpp"
+    llama_dir.mkdir(parents=True, exist_ok=True)
+    (llama_dir / "convert_hf_to_gguf.py").write_text("# stub")
+    model_dir = settings.models_dir / "corrupt__model"
+    model_dir.mkdir(parents=True, exist_ok=True)
+    (model_dir / "config.json").write_text("{not valid json")
+
+    response = await client.post(
+        "/api/v1/export/gguf",
+        json={"model_path": str(model_dir), "outtype": "f16", "output_name": "out"},
+    )
+    assert response.status_code == 422
+    data = response.json()
+    assert data["error"]["code"] == "validation_error"
+    assert "checks" in data["error"]["detail"]
+
+
+@pytest.mark.asyncio
 async def test_gguf_end_to_end_via_api(client, export_service, data_dir):
     service, subprocess = export_service
     settings = get_settings()

--- a/backend/tests/integration/test_inference_api.py
+++ b/backend/tests/integration/test_inference_api.py
@@ -20,8 +20,8 @@ from types import SimpleNamespace
 import pytest
 from starlette.testclient import TestClient
 
-from app.api.inference import _model_dir_name
 from app.config import get_settings
+from app.core.paths import model_dirname
 from app.main import create_app
 from app.services import inference_service as svc
 
@@ -111,7 +111,7 @@ def test_training_active_then_success(data_dir, patched_mlx):
         db_path = settings.db_path
         _insert_run(db_path, "run_1", status="running")
 
-        model_dir = settings.models_dir / _model_dir_name(MODEL_ID)
+        model_dir = settings.models_dir / model_dirname(MODEL_ID)
         model_dir.mkdir(parents=True, exist_ok=True)
 
         def fake_stream_generate(model, tokenizer, prompt, **kwargs):
@@ -157,7 +157,7 @@ def test_model_not_found(data_dir, patched_mlx):
 def test_missing_adapter_path(data_dir, patched_mlx):
     settings = get_settings()
     with TestClient(create_app()) as client:
-        model_dir = settings.models_dir / _model_dir_name(MODEL_ID)
+        model_dir = settings.models_dir / model_dirname(MODEL_ID)
         model_dir.mkdir(parents=True, exist_ok=True)
 
         with client.websocket_connect("/api/v1/ws/chat") as ws:
@@ -170,7 +170,7 @@ def test_missing_adapter_path(data_dir, patched_mlx):
 def test_concurrent_generate_rejected(data_dir, patched_mlx):
     settings = get_settings()
     with TestClient(create_app()) as client:
-        model_dir = settings.models_dir / _model_dir_name(MODEL_ID)
+        model_dir = settings.models_dir / model_dirname(MODEL_ID)
         model_dir.mkdir(parents=True, exist_ok=True)
 
         gate = threading.Event()
@@ -208,7 +208,7 @@ def test_concurrent_generate_rejected(data_dir, patched_mlx):
 def test_cancel_stops_stream(data_dir, patched_mlx):
     settings = get_settings()
     with TestClient(create_app()) as client:
-        model_dir = settings.models_dir / _model_dir_name(MODEL_ID)
+        model_dir = settings.models_dir / model_dirname(MODEL_ID)
         model_dir.mkdir(parents=True, exist_ok=True)
 
         gate = threading.Event()
@@ -231,6 +231,29 @@ def test_cancel_stops_stream(data_dir, patched_mlx):
 
             done = ws.receive_json()
             assert done["type"] == "done"
+
+
+def test_unexpected_generation_error_is_generic(data_dir, patched_mlx):
+    settings = get_settings()
+    with TestClient(create_app()) as client:
+        model_dir = settings.models_dir / model_dirname(MODEL_ID)
+        model_dir.mkdir(parents=True, exist_ok=True)
+
+        secret = "boom at /Users/someone/.cache/private-model-path"
+
+        def exploding_stream_generate(model, tokenizer, prompt, **kwargs):
+            raise RuntimeError(secret)
+            yield  # pragma: no cover — makes this a generator
+
+        patched_mlx.setattr(svc, "_stream_generate_fn", exploding_stream_generate)
+
+        with client.websocket_connect("/api/v1/ws/chat") as ws:
+            ws.send_json(_generate_frame())
+            msg = ws.receive_json()
+            assert msg["type"] == "error"
+            assert msg["code"] == "internal"
+            assert msg["message"] == "internal error"
+            assert secret not in msg["message"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_training_ws.py
+++ b/backend/tests/integration/test_training_ws.py
@@ -1,7 +1,11 @@
+import asyncio
+
 from fastapi.testclient import TestClient
 
 from app.config import get_settings
+from app.core.ws import get_ws_manager
 from app.main import create_app
+from app.schemas.training import JobStatus, MetricEvent, RunSummary, TrainingConfig
 from app.training import manager as manager_module
 from tests.fixtures.training_helpers import (
     ensure_data_dirs,
@@ -121,6 +125,84 @@ def test_ws_train_backfills_persisted_metrics_after_last_step(data_dir):
         assert all(f["data"]["step"] > 1 for f in metric_frames)
         # Already-terminal run: server must close right after the status frame.
         assert backfilled[-1]["status"] == "completed"
+
+        application.dependency_overrides.clear()
+
+
+def _metric(run_id: str, step: int) -> MetricEvent:
+    return MetricEvent(run_id=run_id, step=step, kind="train", loss=1.0 / step, ts="2026-07-15T00:00:00Z")
+
+
+class _BackfillRaceManager:
+    """Fake JobManager whose `get_metrics` broadcasts extra metric frames to
+    the run topic before returning, simulating the pump persisting-and-
+    broadcasting metrics exactly in the backfill window. With the old handler
+    ordering (backfill read, status, THEN subscribe) any frame broadcast here
+    reached no subscriber and was lost; with subscribe-first it is buffered
+    and de-duplicated against the backfill."""
+
+    def __init__(self, run: RunSummary, backfill: list[MetricEvent], live: list[MetricEvent]):
+        self._run = run
+        self._backfill = backfill
+        self._live = live
+        self._done = asyncio.Event()
+
+    async def get_run(self, run_id: str) -> RunSummary:
+        return self._run
+
+    async def get_metrics(self, run_id: str, after_step: int = 0, kind: str | None = None):
+        ws_manager = get_ws_manager()
+        for metric in self._live:
+            await ws_manager.broadcast(
+                f"train/{run_id}", {"type": "metric", "data": metric.model_dump()}
+            )
+        return [m for m in self._backfill if m.step > after_step]
+
+    def done_event(self, run_id: str) -> asyncio.Event:
+        return self._done
+
+
+def test_ws_train_metric_broadcast_during_backfill_is_not_lost_or_duplicated(data_dir):
+    manager_module.reset_job_manager()
+    application = create_app()
+
+    run_id = "run_backfill_race"
+    run = RunSummary(
+        run_id=run_id,
+        name="ws-run",
+        status=JobStatus.RUNNING,
+        config=TrainingConfig.model_validate(_config_payload()),
+        created_at="2026-07-15T00:00:00Z",
+        started_at="2026-07-15T00:00:01Z",
+    )
+    backfill = [_metric(run_id, step) for step in (1, 2, 3)]
+    # Broadcast mid-window: step 3 overlaps the backfill (must not be
+    # duplicated), step 4 is new (was lost with the old ordering).
+    live = [_metric(run_id, 3), _metric(run_id, 4)]
+    fake_manager = _BackfillRaceManager(run, backfill, live)
+
+    with TestClient(application) as client:
+        settings = get_settings()
+        ensure_data_dirs(settings)
+        application.dependency_overrides[manager_module.get_job_manager] = lambda: fake_manager
+
+        with client.websocket_connect(f"/api/v1/ws/train/{run_id}") as ws:
+            ws.send_json({"last_step": 0})
+
+            frames = []
+            metric_steps = []
+            while True:
+                frame = ws.receive_json()
+                frames.append(frame)
+                if frame["type"] == "metric":
+                    metric_steps.append(frame["data"]["step"])
+                    if frame["data"]["step"] == 4:
+                        break
+
+        # No loss: every step arrived. No duplicates: the overlapping step 3
+        # was delivered exactly once.
+        assert sorted(metric_steps) == [1, 2, 3, 4]
+        assert [f["status"] for f in frames if f["type"] == "status"] == ["running"]
 
         application.dependency_overrides.clear()
 

--- a/backend/tests/unit/datasets/test_dataset_import_service.py
+++ b/backend/tests/unit/datasets/test_dataset_import_service.py
@@ -61,6 +61,28 @@ async def test_streaming_import_happy_path_honors_max_rows(import_settings, monk
         await conn.close()
 
 
+def _spy_terminal_writes(monkeypatch) -> list[str]:
+    """Record the status of every terminal write that actually lands on a
+    dataset_imports row (both `finish` and the guarded `finish_if_active`)."""
+    statuses: list[str] = []
+    orig_finish = DatasetImportsRepo.finish
+    orig_finish_if_active = DatasetImportsRepo.finish_if_active
+
+    async def spy_finish(self, id, status, dataset_id, error, finished_at):
+        statuses.append(status)
+        return await orig_finish(self, id, status, dataset_id, error, finished_at)
+
+    async def spy_finish_if_active(self, id, status, dataset_id, error, finished_at):
+        updated = await orig_finish_if_active(self, id, status, dataset_id, error, finished_at)
+        if updated:
+            statuses.append(status)
+        return updated
+
+    monkeypatch.setattr(DatasetImportsRepo, "finish", spy_finish)
+    monkeypatch.setattr(DatasetImportsRepo, "finish_if_active", spy_finish_if_active)
+    return statuses
+
+
 @pytest.mark.asyncio
 async def test_cancel_mid_stream_leaves_no_local_dataset(import_settings, monkeypatch):
     pause_event = threading.Event()
@@ -69,6 +91,7 @@ async def test_cancel_mid_stream_leaves_no_local_dataset(import_settings, monkey
         "app.services.dataset_import_service._load_dataset_stream",
         _pausing_stream_factory(1000, pause_at=20, pause_event=pause_event, resume_event=resume_event),
     )
+    terminal_writes = _spy_terminal_writes(monkeypatch)
 
     service = DatasetImportService(import_settings)
     conn = await make_conn(import_settings)
@@ -83,21 +106,100 @@ async def test_cancel_mid_stream_leaves_no_local_dataset(import_settings, monkey
         # blocking the event loop, so cancellation can be issued mid-stream.
         await asyncio.to_thread(pause_event.wait, 5)
 
+        # cancel_import only signals the worker; the worker owns the terminal
+        # write, so the row is still `running` right after the call.
         cancelled_info = await service.cancel_import(conn, accepted.import_id)
-        assert cancelled_info.status == "cancelled"
+        assert cancelled_info.status == "running"
+        assert terminal_writes == []
 
         resume_event.set()
         await run_task
 
+        # The worker observed the cancel event: exactly one terminal write,
+        # and it is `cancelled` — the worker loop exiting afterwards must not
+        # flip it back to `completed`.
         row = await DatasetImportsRepo(conn).get(accepted.import_id)
         assert row["status"] == "cancelled"
         assert row["dataset_id"] is None
+        assert terminal_writes == ["cancelled"]
 
         job_dir = service._job_dir(accepted.import_id)
         assert not job_dir.exists()
 
         datasets = await DatasetsRepo(conn).list_()
         assert datasets == []
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_cancel_already_completed_import_conflicts_and_keeps_status(
+    import_settings, monkeypatch
+):
+    rows = [{"text": f"row {i}"} for i in range(3)]
+    monkeypatch.setattr(
+        "app.services.dataset_import_service._load_dataset_stream", _fake_stream_factory(rows)
+    )
+
+    service = DatasetImportService(import_settings)
+    conn = await make_conn(import_settings)
+    try:
+        bt = FakeBackgroundTasks()
+        body = DatasetImportRequest(dataset_id="org/done", split="train")
+        accepted = await service.start_import(conn, bt, body)
+        await bt.run_all()
+
+        repo = DatasetImportsRepo(conn)
+        row = await repo.get(accepted.import_id)
+        assert row["status"] == "completed"
+
+        from app.core.errors import ConflictError
+
+        with pytest.raises(ConflictError):
+            await service.cancel_import(conn, accepted.import_id)
+
+        # Even a direct guarded terminal write must not clobber the row.
+        updated = await repo.finish_if_active(
+            accepted.import_id, "cancelled", None, None, "2026-07-15T00:00:00Z"
+        )
+        assert updated is False
+
+        row = await repo.get(accepted.import_id)
+        assert row["status"] == "completed"
+        assert row["dataset_id"] is not None
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_cancel_without_live_worker_finalizes_row(import_settings):
+    """A `running` row with no live worker in this process (e.g. left over
+    from a previous process) must still terminalize on cancel."""
+    service = DatasetImportService(import_settings)
+    conn = await make_conn(import_settings)
+    try:
+        repo = DatasetImportsRepo(conn)
+        await repo.insert(
+            id="di_stale",
+            hf_dataset_id="org/stale",
+            config=None,
+            split="train",
+            name="stale",
+            max_rows=None,
+            status="running",
+            started_at="2026-07-15T00:00:00Z",
+        )
+        job_dir = service._job_dir("di_stale")
+        job_dir.mkdir(parents=True, exist_ok=True)
+        (job_dir / "output.jsonl").write_text('{"text": "partial"}\n')
+
+        info = await service.cancel_import(conn, "di_stale")
+        assert info.status == "cancelled"
+
+        row = await repo.get("di_stale")
+        assert row["status"] == "cancelled"
+        assert row["finished_at"] is not None
+        assert not job_dir.exists()
     finally:
         await conn.close()
 

--- a/backend/tests/unit/test_arena_service.py
+++ b/backend/tests/unit/test_arena_service.py
@@ -41,7 +41,7 @@ class FakeInferenceService:
         yield {"type": "done", "usage": usage}
 
 
-def _frame(model_a: str = "model-a", model_b: str = "model-b") -> ArenaGenerateFrame:
+def _frame(model_a: str = "org/model-a", model_b: str = "org/model-b") -> ArenaGenerateFrame:
     return ArenaGenerateFrame(
         type="generate",
         side_a=ArenaSideSpec(model_id=model_a),
@@ -53,13 +53,13 @@ def _frame(model_a: str = "model-a", model_b: str = "model-b") -> ArenaGenerateF
 
 @pytest.mark.asyncio
 async def test_happy_path_frame_order(tmp_path):
-    (tmp_path / "model-a").mkdir()
-    (tmp_path / "model-b").mkdir()
+    (tmp_path / "org__model-a").mkdir()
+    (tmp_path / "org__model-b").mkdir()
     settings = SimpleNamespace(models_dir=tmp_path)
     fake = FakeInferenceService(
         {
-            str(tmp_path / "model-a"): ["Hi", "!"],
-            str(tmp_path / "model-b"): ["Yo"],
+            str(tmp_path / "org__model-a"): ["Hi", "!"],
+            str(tmp_path / "org__model-b"): ["Yo"],
         }
     )
     service = ArenaService(fake)
@@ -89,14 +89,14 @@ async def test_happy_path_frame_order(tmp_path):
     assert frames[3]["usage"] == {"prompt_tokens": 1, "completion_tokens": 2, "tokens_per_sec": 1.0}
     assert frames[4]["side"] == "b"
     assert frames[6]["side"] == "b"
-    assert fake.calls == [str(tmp_path / "model-a"), str(tmp_path / "model-b")]
+    assert fake.calls == [str(tmp_path / "org__model-a"), str(tmp_path / "org__model-b")]
 
 
 @pytest.mark.asyncio
 async def test_side_a_model_not_found_continues_to_side_b(tmp_path):
-    (tmp_path / "model-b").mkdir()
+    (tmp_path / "org__model-b").mkdir()
     settings = SimpleNamespace(models_dir=tmp_path)
-    fake = FakeInferenceService({str(tmp_path / "model-b"): ["ok"]})
+    fake = FakeInferenceService({str(tmp_path / "org__model-b"): ["ok"]})
     service = ArenaService(fake)
 
     frames = [
@@ -113,11 +113,11 @@ async def test_side_a_model_not_found_continues_to_side_b(tmp_path):
         "type": "error",
         "side": "a",
         "code": "model_not_found",
-        "message": "model 'model-a' not found",
+        "message": "model 'org/model-a' not found",
     }
     assert frames[1] == {"type": "side_start", "side": "b"}
     assert frames[-1] == {"type": "done"}
-    assert fake.calls == [str(tmp_path / "model-b")]
+    assert fake.calls == [str(tmp_path / "org__model-b")]
 
 
 @pytest.mark.asyncio
@@ -150,13 +150,13 @@ async def test_training_active_ends_turn_before_side_a(tmp_path):
 
 @pytest.mark.asyncio
 async def test_cancel_mid_side_a_skips_side_b(tmp_path):
-    (tmp_path / "model-a").mkdir()
-    (tmp_path / "model-b").mkdir()
+    (tmp_path / "org__model-a").mkdir()
+    (tmp_path / "org__model-b").mkdir()
     settings = SimpleNamespace(models_dir=tmp_path)
     fake = FakeInferenceService(
         {
-            str(tmp_path / "model-a"): ["t1", "t2", "t3"],
-            str(tmp_path / "model-b"): ["should-not-appear"],
+            str(tmp_path / "org__model-a"): ["t1", "t2", "t3"],
+            str(tmp_path / "org__model-b"): ["should-not-appear"],
         }
     )
     service = ArenaService(fake)
@@ -174,4 +174,42 @@ async def test_cancel_mid_side_a_skips_side_b(tmp_path):
             registered_callbacks[-1]()
 
     assert [f["type"] for f in frames] == ["side_start", "token", "side_done", "done"]
-    assert fake.calls == [str(tmp_path / "model-a")]
+    assert fake.calls == [str(tmp_path / "org__model-a")]
+
+
+class ExplodingInferenceService:
+    """Raises an internal exception (with sensitive detail) mid-generation."""
+
+    def __init__(self, secret: str) -> None:
+        self._secret = secret
+
+    async def stream_chat(self, *, model_path, adapter_path, messages, params, cancel_event):
+        raise RuntimeError(self._secret)
+        yield  # pragma: no cover — makes this an async generator
+
+
+@pytest.mark.asyncio
+async def test_unexpected_side_error_is_generic(tmp_path):
+    (tmp_path / "org__model-a").mkdir()
+    (tmp_path / "org__model-b").mkdir()
+    settings = SimpleNamespace(models_dir=tmp_path)
+    secret = "mlx blew up at /Users/someone/.cache/private-path"
+    service = ArenaService(ExplodingInferenceService(secret))
+
+    frames = [
+        f
+        async for f in service.run_turn(
+            settings=settings,
+            frame=_frame(),
+            runs_repo=FakeRunsRepo(),
+            register_cancel=lambda cb: None,
+        )
+    ]
+
+    errors = [f for f in frames if f["type"] == "error"]
+    assert [e["side"] for e in errors] == ["a", "b"]
+    for error in errors:
+        assert error["code"] == "internal"
+        assert error["message"] == "internal error"
+        assert secret not in error["message"]
+    assert frames[-1] == {"type": "done"}

--- a/backend/tests/unit/test_export_service.py
+++ b/backend/tests/unit/test_export_service.py
@@ -358,6 +358,44 @@ async def test_preflight_missing_config_fails_arch_and_weights(settings, tmp_pat
 
 
 @pytest.mark.asyncio
+async def test_preflight_corrupt_config_fails_instead_of_raising(settings, tmp_path):
+    llama_dir = settings.cache_dir / "llama.cpp"
+    llama_dir.mkdir(parents=True, exist_ok=True)
+    (llama_dir / "convert_hf_to_gguf.py").write_text("# stub")
+    model_dir = tmp_path / "corrupt-config-model"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text("{not valid json")
+
+    service = ExportService(settings, run_subprocess=RecordingSubprocess())
+    report = await service.preflight_gguf(str(model_dir))
+
+    assert report.ok is False
+    by_name = {c.name: c for c in report.checks}
+    assert by_name["arch_supported"].ok is False
+    assert "config.json is not valid JSON" in by_name["arch_supported"].message
+    assert by_name["weights_dequantized"].ok is False
+    assert "config.json is not valid JSON" in by_name["weights_dequantized"].message
+
+
+@pytest.mark.asyncio
+async def test_preflight_non_object_config_fails_instead_of_raising(settings, tmp_path):
+    llama_dir = settings.cache_dir / "llama.cpp"
+    llama_dir.mkdir(parents=True, exist_ok=True)
+    (llama_dir / "convert_hf_to_gguf.py").write_text("# stub")
+    model_dir = tmp_path / "list-config-model"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text("[1, 2, 3]")
+
+    service = ExportService(settings, run_subprocess=RecordingSubprocess())
+    report = await service.preflight_gguf(str(model_dir))
+
+    assert report.ok is False
+    by_name = {c.name: c for c in report.checks}
+    assert by_name["arch_supported"].ok is False
+    assert by_name["weights_dequantized"].ok is False
+
+
+@pytest.mark.asyncio
 async def test_preflight_respects_explicit_llama_cpp_dir_setting(settings, tmp_path):
     custom_dir = tmp_path / "custom-llama-cpp"
     custom_dir.mkdir()
@@ -420,6 +458,29 @@ async def test_gguf_422_when_preflight_fails(settings, conn):
         await service.start_gguf(conn, body, BackgroundTasks())
 
     assert "checks" in excinfo.value.detail
+
+
+@pytest.mark.asyncio
+async def test_gguf_start_corrupt_config_raises_validation_error_not_500(settings, conn, tmp_path):
+    # A corrupt config.json must surface as the normal preflight-failure 422,
+    # never as an unhandled JSONDecodeError (raw 500).
+    llama_dir = settings.cache_dir / "llama.cpp"
+    llama_dir.mkdir(parents=True, exist_ok=True)
+    (llama_dir / "convert_hf_to_gguf.py").write_text("# stub")
+    model_dir = tmp_path / "corrupt-config-model"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text("{not valid json")
+
+    subprocess = RecordingSubprocess()
+    service = ExportService(settings, run_subprocess=subprocess)
+    body = GGUFRequest(model_path=str(model_dir), outtype="f16", output_name="my-gguf")
+
+    with pytest.raises(ValidationAppError) as excinfo:
+        await service.start_gguf(conn, body, BackgroundTasks())
+
+    failing = excinfo.value.detail["checks"]
+    assert any("config.json is not valid JSON" in c["message"] for c in failing)
+    assert subprocess.calls == []
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_paths.py
+++ b/backend/tests/unit/test_paths.py
@@ -1,0 +1,46 @@
+"""Unit tests for app.core.paths — the ONE canonical model-id <-> dirname mapping.
+
+The semantics replicate what the model registry has always written to disk;
+these tests pin them down so no component drifts back to its own variant.
+"""
+
+from app.core.paths import model_dirname, model_id_from_dirname
+
+
+def test_org_name_maps_to_double_underscore():
+    assert model_dirname("mlx-community/SmolLM-135M-Instruct-4bit") == (
+        "mlx-community__SmolLM-135M-Instruct-4bit"
+    )
+
+
+def test_org_name_round_trips():
+    model_id = "mlx-community/Qwen2.5-0.5B-Instruct-4bit"
+    assert model_id_from_dirname(model_dirname(model_id)) == model_id
+
+
+def test_name_without_org_gets_underscore_prefix():
+    # Historical registry behavior: a slashless id is stored as "_<name>".
+    assert model_dirname("gpt2") == "_gpt2"
+
+
+def test_name_without_org_does_not_round_trip():
+    # Also historical: "_gpt2" contains no "__", so the inverse returns it
+    # unchanged instead of recovering "gpt2". Documented, not "fixed" —
+    # existing directories on users' disks depend on this mapping.
+    assert model_id_from_dirname(model_dirname("gpt2")) == "_gpt2"
+
+
+def test_multiple_slashes_only_first_is_replaced():
+    # Canonical behavior for exotic ids: only the FIRST slash becomes "__"
+    # (this is what the registry, chat and arena already did; the training
+    # manager used to replace every slash and has been aligned to this).
+    assert model_dirname("org/sub/name") == "org__sub/name"
+    assert model_id_from_dirname("org__sub/name") == "org/sub/name"
+
+
+def test_dirname_without_separator_is_returned_unchanged():
+    assert model_id_from_dirname("plain-dir") == "plain-dir"
+
+
+def test_inverse_splits_on_first_double_underscore_only():
+    assert model_id_from_dirname("org__name__variant") == "org/name__variant"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,6 +25,7 @@ affect the contract.
 | `api/recipes.py` | `POST /recipes/convert`, `GET /recipes/jobs/{id}` — document→dataset conversion jobs. Thin wrapper over `services/recipe_service.py`. |
 | `api/history.py` | `GET /runs/history` (filter/sort/paginate) and `POST /train/jobs/{run_id}/clone`. No dedicated service — talks to `RunsRepo` directly, same pattern as `api/system.py`. |
 | `core/errors.py` | `AppError` hierarchy (`NotFoundError`, `ConflictError`, `ValidationAppError`, `TrainingActiveError`, `InternalError`) and the exception handlers that turn them (plus `RequestValidationError` and any uncaught exception) into the `{"error": {code, message, detail}}` shape from `docs/api.md`. |
+| `core/paths.py` | Canonical `model_id` ↔ on-disk directory-name mapping (`model_dirname` / `model_id_from_dirname`), shared by the registry, training manager, export, chat and arena so every component resolves the same directories. |
 | `core/process.py` | Process-group spawn/kill helpers (`spawn_process_group`, `terminate_process_group`, `kill_process_group`, PID-file read/write, liveness check). Used by both the training worker and orphan reaping. |
 | `core/ws.py` | `ConnectionManager` — topic-based WebSocket pub/sub (`subscribe`/`unsubscribe`/`broadcast`), used by the training WS. Downloads and chat WS use their own local queue-based mechanisms instead. |
 | `db/database.py` | SQLite schema + versioned migrations (`MIGRATIONS` list, `schema_version` table), `init_db`, `get_connection`. |


### PR DESCRIPTION
Closes #8 — all five items of the robustness bundle, in three commits. No API-contract changes (error shapes and `code` values are untouched; only internal behavior and free-text messages change).

## 1. Import cancel race (`d3ef69b`)

`cancel_import` wrote `finish(cancelled)` and `rmtree`'d the job directory while `_run_job` could still be mid-write and would later call its own `finish()` — a double terminal write (a cancelled import could flip back to `completed`) or a crash when the directory vanished. Now: `cancel_import` only sets the cancel event when a live worker exists; the worker owns the terminal DB write and cleanup. A stale `running` row with no live worker is still finalized by cancel itself. All terminal writes go through the new atomic `DatasetImportsRepo.finish_if_active`, which refuses to overwrite an already-terminal row. Cancel now honestly returns `running` until the worker lands the terminal write (mirrors the train-job cancel semantics already in the contract).

## 2. `/ws/train` backfill-subscribe metric gap (`66fcc7b`)

The handler read persisted metrics and only then subscribed to the live topic — a metric broadcast in that window was never delivered. Now a buffering subscriber is registered *before* the backfill read; frames arriving during backfill are queued, drained with `(kind, step)` de-duplication against what backfill already sent, then the wrapper switches to passthrough. Unsubscribe moved to a `finally` covering every exit path. The new test was verified to hang under the old ordering and pass under the new one.

## 3–5. Preflight, error leak, model-path helper (`9c309e3`)

- **`preflight_gguf` no longer 500s on corrupt `config.json`**: unreadable/invalid/non-object config now fails both checks with "config.json is not valid JSON: …" and returns `ok: false`; `POST /export/gguf` funnels the same condition into its documented 422.
- **No internal error text to clients**: the catch-all HTTP handler and the bare-`Exception` WS paths (chat, arena, arena per-side) now `logger.exception()` server-side and send a generic message ("internal server error" / "internal error"). Typed `AppError` / validation paths keep their real messages.
- **One canonical `model_id ↔ dirname` mapping** in new `app/core/paths.py`, replicating the registry's on-disk semantics (first slash → `__`; `_name` prefix for slashless ids) and replacing five divergent copies (manager, worker, model_registry, inference, arena_service, export_service). The copies only coincided for `org/name` ids; slashless/multi-slash ids now resolve to the directories the registry actually writes. `docs/architecture.md` module map updated.

## Tests

+18 tests: terminal-write-ownership and double-cancel guards for imports; WS no-loss/no-duplicate metric delivery; corrupt-config preflight (service + HTTP, both endpoints); 500-body leak assertions (generic text present, original exception text absent, typed errors keep messages); WS internal-error frames; 7 unit tests pinning the canonical path mapping.

## Verification

- `make test`: backend **394 passed**, frontend **193 passed** (baseline 376/193)
- `make lint`: ruff clean, `tsc --noEmit` clean
- No module-level mlx imports (verified by grep and by importing `app.main` in the mlx-less venv)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UEysgYYG512HSnoKf5cgm

---
_Generated by [Claude Code](https://claude.ai/code/session_014UEysgYYG512HSnoKf5cgm)_