### PR TITLE
Job-creation lock, nullable worker metrics, and CI build/oxlint/matrix (issues #4, #6, #13)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,21 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   backend:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
     defaults:
       run:
         working-directory: backend
+    env:
+      UV_PYTHON: ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v4
 
@@ -17,17 +26,19 @@ jobs:
         uses: astral-sh/setup-uv@v3
         with:
           version: "latest"
+          enable-cache: true
+          cache-dependency-glob: backend/uv.lock
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: uv sync
 
       - name: Ruff check
-        run: uv run ruff check .
+        run: uv run ruff check . ../e2e
 
       - name: Pytest
         run: uv run pytest
@@ -53,5 +64,11 @@ jobs:
       - name: Type check
         run: npx tsc --noEmit
 
+      - name: Oxlint
+        run: npx oxlint
+
       - name: Vitest
         run: npx vitest run
+
+      - name: Build
+        run: npm run build

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install dev test test-backend test-frontend lint e2e e2e-faz2
+.PHONY: install dev build test test-backend test-frontend lint e2e e2e-faz2
 
 install:
 	cd backend && uv sync --all-extras --all-groups
@@ -10,6 +10,11 @@ dev:
 	( cd frontend && npm run dev -- --port 5173 ) & \
 	wait
 
+# Production build of the frontend (type-checks via `tsc -b`, then bundles
+# with Vite). The backend has no build step; it runs from source.
+build:
+	cd frontend && npm run build
+
 test: test-backend test-frontend
 
 test-backend:
@@ -19,8 +24,9 @@ test-frontend:
 	cd frontend && npx vitest run
 
 lint:
-	cd backend && uv run ruff check .
+	cd backend && uv run ruff check . ../e2e
 	cd frontend && npx tsc --noEmit
+	cd frontend && npx oxlint
 
 # Real end-to-end smoke test against the MLX runtime: downloads a tiny model,
 # trains a LoRA adapter, chats with it, and fuses the result. Needs Apple

--- a/backend/app/schemas/events.py
+++ b/backend/app/schemas/events.py
@@ -10,13 +10,24 @@ class WorkerStarted(BaseModel):
 
 
 class WorkerMetric(BaseModel):
+    """Train-metric line from the worker.
+
+    The rate/memory fields are nullable: `WorkerCallback.on_train_loss_report`
+    forwards `train_info.get(...)` values, and mlx-lm-lora may omit any of
+    those keys — a missing rate must not make the whole metric unparseable
+    (it would silently degrade to a `log_line`). `step` and `loss` stay
+    required: a metric without them is unusable, so such a line intentionally
+    falls back to `log_line`. Mirrors `MetricEvent`, which is nullable
+    end-to-end (docs/api.md: "rate fields may be null").
+    """
+
     event: Literal["metric"]
     step: int
     loss: float
-    learning_rate: float
-    it_per_sec: float
-    tokens_per_sec: float
-    peak_memory_gb: float
+    learning_rate: float | None = None
+    it_per_sec: float | None = None
+    tokens_per_sec: float | None = None
+    peak_memory_gb: float | None = None
 
 
 class WorkerValMetric(BaseModel):

--- a/backend/app/training/manager.py
+++ b/backend/app/training/manager.py
@@ -125,6 +125,15 @@ class JobManager:
         self._cancel_grace_seconds = cancel_grace_seconds
 
         self._active_run_id: str | None = None
+        # Serializes the check-then-insert-then-spawn critical section in
+        # `create_job` (and the startup sweep in `reap_orphans`, which also
+        # rewrites active-run state). Without it, two concurrent
+        # POST /train/jobs can both observe zero active runs and both spawn
+        # workers, breaking the single-training-job invariant. Read paths
+        # (get_run/list_runs/get_metrics/get_logs) and the shrink-only paths
+        # (cancel/_finalize, which never *create* active runs and are
+        # idempotent via `_finalized`) deliberately do not take it.
+        self._create_lock = asyncio.Lock()
         self._processes: dict[str, subprocess.Popen] = {}
         self._pump_tasks: dict[str, asyncio.Task] = {}
         self._ring_buffers: dict[str, deque] = {}
@@ -156,50 +165,60 @@ class JobManager:
         if not model_dir.is_dir():
             raise NotFoundError(f"model '{config.model_id}' not found")
 
-        async with get_connection(self._settings.db_path) as conn:
-            dataset_row = await DatasetsRepo(conn).get(config.dataset_id)
-            if dataset_row is None:
-                raise NotFoundError(f"dataset '{config.dataset_id}' not found")
+        # Everything from the active-run check to the worker spawn must be
+        # atomic w.r.t. other create_job calls: `list_active` + `insert` is a
+        # classic check-then-act race, and the spawn must happen before the
+        # next caller's check so the invariant (at most one queued/running
+        # run) holds. The dataset validation reads ride along inside the lock
+        # because they share the DB connection; create_job is rare and cheap,
+        # so serializing it entirely is fine.
+        async with self._create_lock:
+            async with get_connection(self._settings.db_path) as conn:
+                dataset_row = await DatasetsRepo(conn).get(config.dataset_id)
+                if dataset_row is None:
+                    raise NotFoundError(f"dataset '{config.dataset_id}' not found")
 
-            train_file = self._settings.datasets_dir / config.dataset_id / "data" / "train.jsonl"
-            if not train_file.is_file():
-                raise ValidationAppError(
-                    f"dataset '{config.dataset_id}' has no train split; "
-                    "call POST /datasets/{id}/split first"
+                train_file = (
+                    self._settings.datasets_dir / config.dataset_id / "data" / "train.jsonl"
+                )
+                if not train_file.is_file():
+                    raise ValidationAppError(
+                        f"dataset '{config.dataset_id}' has no train split; "
+                        "call POST /datasets/{id}/split first"
+                    )
+
+                allowed_formats = DATASET_FORMAT_COMPAT[config.train_mode.value]
+                if dataset_row["format"] not in allowed_formats:
+                    raise ValidationAppError(
+                        f"dataset format '{dataset_row['format']}' is not compatible "
+                        f"with train_mode '{config.train_mode.value}' "
+                        f"(expected one of {sorted(allowed_formats)})"
+                    )
+
+                runs_repo = RunsRepo(conn)
+                active = await runs_repo.list_active()
+                if active:
+                    raise TrainingActiveError("a training job is already queued or running")
+
+                run_id = f"run_{uuid.uuid4().hex[:12]}"
+                created_at = _now_iso()
+                config_json = config.model_dump_json()
+                await runs_repo.insert(
+                    run_id=run_id,
+                    name=config.name,
+                    status=JobStatus.QUEUED.value,
+                    config_json=config_json,
+                    model_id=config.model_id,
+                    dataset_id=config.dataset_id,
+                    train_mode=config.train_mode.value,
+                    created_at=created_at,
                 )
 
-            allowed_formats = DATASET_FORMAT_COMPAT[config.train_mode.value]
-            if dataset_row["format"] not in allowed_formats:
-                raise ValidationAppError(
-                    f"dataset format '{dataset_row['format']}' is not compatible "
-                    f"with train_mode '{config.train_mode.value}' "
-                    f"(expected one of {sorted(allowed_formats)})"
-                )
+            run_dir = self._settings.runs_dir / run_id
+            run_dir.mkdir(parents=True, exist_ok=True)
+            (run_dir / "config.json").write_text(config_json)
 
-            runs_repo = RunsRepo(conn)
-            active = await runs_repo.list_active()
-            if active:
-                raise TrainingActiveError("a training job is already queued or running")
-
-            run_id = f"run_{uuid.uuid4().hex[:12]}"
-            created_at = _now_iso()
-            config_json = config.model_dump_json()
-            await runs_repo.insert(
-                run_id=run_id,
-                name=config.name,
-                status=JobStatus.QUEUED.value,
-                config_json=config_json,
-                model_id=config.model_id,
-                dataset_id=config.dataset_id,
-                train_mode=config.train_mode.value,
-                created_at=created_at,
-            )
-
-        run_dir = self._settings.runs_dir / run_id
-        run_dir.mkdir(parents=True, exist_ok=True)
-        (run_dir / "config.json").write_text(config_json)
-
-        await self._start_worker(run_id, run_dir)
+            await self._start_worker(run_id, run_dir)
 
         return await self.get_run(run_id)
 
@@ -265,7 +284,17 @@ class JobManager:
         return await self.get_run(run_id)
 
     async def reap_orphans(self) -> None:
-        """Startup hook: fail/cancel any run left `queued`/`running` from a crash."""
+        """Startup hook: fail/cancel any run left `queued`/`running` from a crash.
+
+        Holds `_create_lock` so a concurrent `create_job` can neither observe
+        a half-swept active set nor insert a fresh run mid-sweep (and so the
+        unconditional `_active_run_id = None` below cannot clobber a run being
+        started concurrently).
+        """
+        async with self._create_lock:
+            await self._reap_orphans_locked()
+
+    async def _reap_orphans_locked(self) -> None:
         async with get_connection(self._settings.db_path) as conn:
             active_rows = await RunsRepo(conn).list_active()
 

--- a/backend/tests/fixtures/fake_worker.py
+++ b/backend/tests/fixtures/fake_worker.py
@@ -8,7 +8,8 @@ dependency. Driven entirely by environment variables so
 `[sys.executable, str(fake_worker.py)]` form.
 
 Env vars:
-  FAKE_WORKER_SCENARIO: happy | crash | ignore_sigterm | garbage (default: happy)
+  FAKE_WORKER_SCENARIO: happy | crash | ignore_sigterm | garbage | null_metrics
+      (default: happy)
   FAKE_WORKER_ITERS: number of training metric steps to emit (default: 3)
   FAKE_WORKER_STEP_DELAY: seconds to sleep between emitted lines (default: 0.01)
   FAKE_WORKER_ADAPTER_PATH: adapter_path reported in checkpoint/done events
@@ -103,6 +104,41 @@ def _run_ignore_sigterm(iters: int) -> None:
         time.sleep(0.05)
 
 
+def _run_null_metrics(iters: int) -> None:  # noqa: ARG001 — scripted, fixed line count
+    """Metric lines with null optional fields (mlx-lm-lora omitted keys).
+
+    Emits: one fully-populated metric, one metric whose rate/memory fields
+    are all null (must still parse as a metric), and one "metric" whose loss
+    is null (must fall back to a log_line), then done.
+    """
+    _emit({"event": "started", "pid": os.getpid()})
+    _sleep()
+    _emit(_metric_frame(1, 2.5))
+    _sleep()
+    _emit(
+        {
+            "event": "metric",
+            "step": 2,
+            "loss": 2.4,
+            "learning_rate": None,
+            "it_per_sec": None,
+            "tokens_per_sec": None,
+            "peak_memory_gb": None,
+        }
+    )
+    _sleep()
+    _emit({"event": "metric", "step": 3, "loss": None})
+    _sleep()
+    _emit(
+        {
+            "event": "done",
+            "adapter_path": _adapter_path(),
+            "final_train_loss": 2.4,
+            "final_val_loss": None,
+        }
+    )
+
+
 def _run_garbage(iters: int) -> None:
     _emit({"event": "started", "pid": os.getpid()})
     _sleep()
@@ -129,6 +165,7 @@ _SCENARIOS = {
     "crash": _run_crash,
     "ignore_sigterm": _run_ignore_sigterm,
     "garbage": _run_garbage,
+    "null_metrics": _run_null_metrics,
 }
 
 

--- a/backend/tests/unit/test_schemas.py
+++ b/backend/tests/unit/test_schemas.py
@@ -141,6 +141,43 @@ class TestParseWorkerLine:
         assert event.tokens_per_sec == 512.0
         assert event.peak_memory_gb == 3.4
 
+    def test_metric_with_missing_rate_fields_parses_with_nones(self):
+        # mlx-lm-lora may omit keys like tokens_per_second/peak_memory; the
+        # worker then emits nulls (or the keys are absent entirely). The
+        # metric must still parse instead of degrading to a log_line.
+        line = '{"event": "metric", "step": 10, "loss": 2.3, "learning_rate": 1e-5}'
+        event = parse_worker_line(line)
+        assert isinstance(event, WorkerMetric)
+        assert event.step == 10
+        assert event.loss == 2.3
+        assert event.learning_rate == 1e-5
+        assert event.it_per_sec is None
+        assert event.tokens_per_sec is None
+        assert event.peak_memory_gb is None
+
+    def test_metric_with_explicit_null_rate_fields_parses_with_nones(self):
+        line = (
+            '{"event": "metric", "step": 5, "loss": 1.5, "learning_rate": null, '
+            '"it_per_sec": null, "tokens_per_sec": null, "peak_memory_gb": null}'
+        )
+        event = parse_worker_line(line)
+        assert isinstance(event, WorkerMetric)
+        assert event.step == 5
+        assert event.loss == 1.5
+        assert event.learning_rate is None
+        assert event.it_per_sec is None
+        assert event.tokens_per_sec is None
+        assert event.peak_memory_gb is None
+
+    def test_metric_with_null_loss_falls_back_to_log_line(self):
+        # Documented behavior: step and loss stay required — a metric without
+        # them is unusable, so the line is treated as a plain log_line
+        # (parse_worker_line -> None) rather than a metric.
+        assert parse_worker_line('{"event": "metric", "step": 3, "loss": null}') is None
+
+    def test_metric_with_null_step_falls_back_to_log_line(self):
+        assert parse_worker_line('{"event": "metric", "step": null, "loss": 2.0}') is None
+
     def test_invalid_json_returns_none(self):
         assert parse_worker_line("not json {") is None
 

--- a/backend/tests/unit/test_training_manager.py
+++ b/backend/tests/unit/test_training_manager.py
@@ -182,6 +182,60 @@ async def test_second_job_conflicts_while_first_active(settings):
 
 
 @pytest.mark.asyncio
+async def test_concurrent_create_jobs_only_one_wins(settings, monkeypatch):
+    """Issue #4: N concurrent create_job calls -> exactly one run, N-1 409s.
+
+    The check-then-insert window is widened deterministically by making
+    `RunsRepo.list_active` yield to the event loop several times before
+    returning: without the manager's create-lock, every gathered create_job
+    would pass the empty-active check before any insert lands and all five
+    would spawn workers. No wall-clock sleeps involved.
+    """
+    from app.db import repositories
+
+    setup_model_dir(settings)
+    await setup_dataset(settings)
+
+    original_list_active = repositories.RunsRepo.list_active
+
+    async def yielding_list_active(self):
+        rows = await original_list_active(self)
+        for _ in range(10):
+            await asyncio.sleep(0)
+        return rows
+
+    monkeypatch.setattr(repositories.RunsRepo, "list_active", yielding_list_active)
+
+    # ignore_sigterm keeps the winning worker alive (it loops until killed),
+    # so the losers' active-run checks are guaranteed to see it.
+    manager = JobManager(
+        settings=settings,
+        worker_argv_factory=make_worker_argv_factory(
+            "ignore_sigterm", FAKE_WORKER_ITERS=1000, FAKE_WORKER_STEP_DELAY=0.01
+        ),
+        cancel_grace_seconds=0.2,
+    )
+
+    results = await asyncio.gather(
+        *(manager.create_job(make_config(name=f"job-{i}")) for i in range(5)),
+        return_exceptions=True,
+    )
+
+    winners = [r for r in results if not isinstance(r, BaseException)]
+    losers = [r for r in results if isinstance(r, BaseException)]
+    assert len(winners) == 1
+    assert all(isinstance(exc, TrainingActiveError) for exc in losers)
+    assert len(losers) == 4
+
+    _, total = await manager.list_runs()
+    assert total == 1  # exactly one row ever hit the DB
+
+    # Cleanup: don't leak the lingering ignore-SIGTERM subprocess.
+    await manager.cancel(winners[0].run_id)
+    await _run_to_completion(manager, winners[0].run_id, timeout=5.0)
+
+
+@pytest.mark.asyncio
 async def test_cancel_graceful_term_is_honored_quickly(settings):
     setup_model_dir(settings)
     await setup_dataset(settings)
@@ -269,6 +323,51 @@ async def test_garbage_lines_become_log_lines_and_job_still_completes(settings):
 
     final = await manager.get_run(summary.run_id)
     assert final.status.value == "completed"
+
+
+@pytest.mark.asyncio
+async def test_null_field_metrics_are_stored_not_dropped(settings):
+    """Issue #6: metrics with null rate/memory fields survive end to end.
+
+    The worker forwards `train_info.get(...)` values that are None whenever
+    mlx-lm-lora omits a key; such lines must land in the metrics DB and the
+    ring buffer as metrics (with None fields), not degrade to log_lines.
+    A line whose *loss* is null stays a log_line — that is the documented
+    fallback for a genuinely unusable metric.
+    """
+    setup_model_dir(settings)
+    await setup_dataset(settings)
+    manager = JobManager(
+        settings=settings,
+        worker_argv_factory=make_worker_argv_factory("null_metrics", FAKE_WORKER_STEP_DELAY=0.0),
+    )
+    summary = await manager.create_job(make_config())
+    await _run_to_completion(manager, summary.run_id)
+
+    final = await manager.get_run(summary.run_id)
+    assert final.status.value == "completed"
+
+    # Steps 1 (full) and 2 (null rates) are persisted; step 3 (null loss) is not.
+    metrics = await manager.get_metrics(summary.run_id, kind="train")
+    assert [m.step for m in metrics] == [1, 2]
+    null_metric = metrics[1]
+    assert null_metric.loss == 2.4
+    assert null_metric.learning_rate is None
+    assert null_metric.it_per_sec is None
+    assert null_metric.tokens_per_sec is None
+    assert null_metric.peak_memory_gb is None
+
+    # Same frames went to the ring buffer (== what the WS broadcast carried).
+    ring = manager._ring_buffers[summary.run_id]
+    metric_frames = [f for f in ring if f["type"] == "metric" and f["data"]["kind"] == "train"]
+    assert [f["data"]["step"] for f in metric_frames] == [1, 2]
+    assert metric_frames[1]["data"]["loss"] == 2.4
+    assert metric_frames[1]["data"]["tokens_per_sec"] is None
+    assert metric_frames[1]["data"]["peak_memory_gb"] is None
+
+    # The loss-null line fell back to a raw log_line frame.
+    log_frames = [f for f in ring if f["type"] == "log_line"]
+    assert any('"step": 3' in f["line"] and '"loss": null' in f["line"] for f in log_frames)
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/datasets/FormatBadge.tsx
+++ b/frontend/src/components/datasets/FormatBadge.tsx
@@ -9,7 +9,7 @@ interface FormatMeta {
 
 // Each format gets its own dot color (inline style, so it doesn't depend on
 // Tailwind's utility-ordering cascade) layered on top of the closest Badge
-// variant tint, giving six visually distinct combinations.
+// variant tint, giving visually distinct combinations.
 const FORMAT_META: Record<DatasetFormat, FormatMeta> = {
   chat: { variant: 'info', color: '#38bdf8', label: 'Chat' },
   completions: { variant: 'success', color: '#4ade80', label: 'Completions' },
@@ -17,6 +17,7 @@ const FORMAT_META: Record<DatasetFormat, FormatMeta> = {
   dpo: { variant: 'warning', color: '#fbbf24', label: 'DPO' },
   orpo: { variant: 'danger', color: '#f87171', label: 'ORPO' },
   grpo: { variant: 'info', color: '#a78bfa', label: 'GRPO' },
+  ftpo: { variant: 'warning', color: '#fb923c', label: 'FTPO' },
 }
 
 interface FormatBadgeProps {


### PR DESCRIPTION
Closes #4, closes #6, closes #13 — three commits, one per concern.

## #4 — create_job check-then-insert race (`8828e2e`)

The `list_active` check and the subsequent insert/spawn had no synchronization: two concurrent `POST /train/jobs` could both observe zero active runs and both spawn workers on one Metal GPU. The whole check-then-insert-then-spawn section now runs under an `asyncio.Lock` on the `JobManager` (`reap_orphans` takes it too, since it rewrites active-run state); pure reads and the shrink-only cancel/finalize paths deliberately stay lock-free. New test fires 5 concurrent `create_job` calls with a deterministically widened race window (event-loop yields, no wall-clock sleeps) — exactly one wins, four get `training_active`, one DB row; verified the test catches the bug with the lock neutralized.

The DB partial-unique-index backstop from the issue was **deliberately skipped**: repairing an already-violating DB inside a migration would have to demote active rows *before* `reap_orphans` gets a chance to kill their live worker PIDs. The manager is process-local in a single-process API, so the lock fully covers the invariant.

## #6 — null-field metrics silently dropped (`8828e2e`)

`WorkerMetric` required every rate/memory field non-null, so any metric line where mlx-lm-lora omitted a key (e.g. `peak_memory`, `tokens_per_second` on some steps) failed parsing and was demoted to a `log_line` — silently missing from the DB, the metrics API and the WS stream. `learning_rate` / `it_per_sec` / `tokens_per_sec` / `peak_memory_gb` are now `float | None`, matching the already-nullable `MetricEvent`, DB columns and contract ("rate fields may be null"); `step`/`loss` stay required. End-to-end test through the real pump: a null-field metric lands in `get_metrics` and the ring buffer; a null-loss line still falls back to `log_line`.

## #13 — CI: frontend build, oxlint, e2e lint, hardening (`1f043b0` + `54ffe0c`)

- **Frontend job now runs the real production build** (`npm run build` = `tsc -b && vite build`) and **oxlint**; new `make build` mirrors it locally, and `make lint` gains oxlint + e2e ruff legs.
- This immediately paid off: the existing `tsc --noEmit` step is vacuous (the solution-style root tsconfig has `files: []`, so it checks nothing), and the real `tsc -b` caught a shipped bug — `FormatBadge`'s `FORMAT_META` was missing the `ftpo` entry added in the 3.0.0 upgrade. Fixed in `54ffe0c`.
- **Backend matrix**: Python 3.11 / 3.12 / 3.13 (`UV_PYTHON` pins the matrix interpreter; 3.13 verified locally against the frozen lock — 397 tests passed), uv caching keyed on `backend/uv.lock`, and `concurrency.cancel-in-progress` so superseded pushes stop stale runs.
- Out of scope by design: coverage upload and a self-hosted Apple Silicon e2e job (no runner exists) — noted here so the checklist's "consider" items are accounted for.

## Verification

- `make test`: backend **403 passed** (+7), frontend **193 passed**
- `make lint`: ruff (backend + e2e) clean, tsc clean, oxlint exit 0 (5 pre-existing warnings, untouched files)
- `make build`: production bundle builds (`✓ built in ~0.5s`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UEysgYYG512HSnoKf5cgm

---
_Generated by [Claude Code](https://claude.ai/code/session_014UEysgYYG512HSnoKf5cgm)_