### PR TITLE
Production distribution: serve the built frontend from FastAPI + mlxlf single-command startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install dev build test test-backend test-frontend lint e2e e2e-faz2
+.PHONY: install dev build run test test-backend test-frontend lint e2e e2e-faz2
 
 install:
 	cd backend && uv sync --all-extras --all-groups
@@ -14,6 +14,12 @@ dev:
 # with Vite). The backend has no build step; it runs from source.
 build:
 	cd frontend && npm run build
+
+# Production run: build the frontend, then serve API + UI from a single
+# FastAPI process on :8000 and open the browser. For flags (--host, --port,
+# --no-browser) call `cd backend && uv run mlxlf ...` directly.
+run: build
+	cd backend && uv run mlxlf
 
 test: test-backend test-frontend
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,25 @@ make dev       # backend on :8000, frontend on :5173
 Open http://localhost:5173. The backend also serves interactive API docs at
 http://localhost:8000/docs.
 
+## Production / single-command run
+
+Build the frontend once, then serve API + UI from a single FastAPI process:
+
+```bash
+make run       # = make build, then `cd backend && uv run mlxlf`
+```
+
+`mlxlf` starts uvicorn on http://127.0.0.1:8000 (serving the built frontend
+from `frontend/dist`) and opens it in your default browser. Flags:
+
+```bash
+cd backend && uv run mlxlf --host 0.0.0.0 --port 9000 --no-browser
+```
+
+If the frontend build is missing, `mlxlf` still starts but serves the API
+only (it prints a hint to run `make build`). Set `MLXLF_STATIC_DIR` to serve
+a build from a non-default location.
+
 ## Configuration
 
 All settings are environment variables with an `MLXLF_` prefix (see
@@ -69,6 +88,7 @@ All settings are environment variables with an `MLXLF_` prefix (see
 | `MLXLF_PORT`         | `8000`                     | Backend port.                                                       |
 | `MLXLF_HF_TOKEN`     | *(unset)*                  | Hugging Face token, used for gated/private models and higher rate limits. |
 | `MLXLF_LLAMA_CPP_DIR` | *(unset)*                  | Path to a `llama.cpp` checkout containing `convert_hf_to_gguf.py`, required for GGUF export. Falls back to `<data_dir>/cache/llama.cpp`. |
+| `MLXLF_STATIC_DIR`   | `<repo>/frontend/dist`     | Built frontend served at `/` in production (`mlxlf`). If it contains no `index.html`, nothing is mounted (dev mode). |
 
 ### Data directory layout
 

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -1,0 +1,49 @@
+"""`mlxlf` — single-command production entry point.
+
+Starts uvicorn serving `app.main:app` (API + the built frontend, see
+`SPAStaticFiles` in `app.main`) and opens the browser. This module must stay
+mlx-free at import time: it imports only stdlib + uvicorn, and `app.main` is
+loaded lazily by uvicorn via its import string.
+"""
+
+from __future__ import annotations
+
+import argparse
+import webbrowser
+
+import uvicorn
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        prog="mlxlf",
+        description="Run the mlx-lora-finetuner server (API + built frontend).",
+    )
+    parser.add_argument("--host", default="127.0.0.1", help="bind host (default: 127.0.0.1)")
+    parser.add_argument("--port", type=int, default=8000, help="bind port (default: 8000)")
+    parser.add_argument(
+        "--no-browser", action="store_true", help="do not open the app in the default browser"
+    )
+    args = parser.parse_args(argv)
+
+    # Lazy import: keeps this module importable without the app's settings
+    # machinery (and, transitively, without ever touching mlx).
+    from app.config import get_settings
+
+    static_dir = get_settings().static_dir
+    if not (static_dir / "index.html").is_file():
+        print(
+            f"No built frontend found at {static_dir} — serving API only. "
+            "Run `make build` first (or set MLXLF_STATIC_DIR) to serve the UI."
+        )
+
+    url = f"http://{args.host}:{args.port}"
+    if not args.no_browser:
+        # Opened just before uvicorn.run blocks; the browser takes longer to
+        # start than the server does.
+        webbrowser.open(url)
+    uvicorn.run("app.main:app", host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -12,6 +12,12 @@ class Settings(BaseSettings):
     port: int = 8000
     hf_token: str | None = None
     llama_cpp_dir: Path | None = None
+    # Built frontend to serve from FastAPI in production. Defaults to the
+    # repo's `frontend/dist` (resolved relative to this file, so a
+    # `make build && mlxlf` from a git clone just works); override with
+    # MLXLF_STATIC_DIR. When the directory has no index.html, nothing is
+    # mounted and the app is API-only (the dev/test default).
+    static_dir: Path = Path(__file__).resolve().parents[2] / "frontend" / "dist"
 
     @property
     def models_dir(self) -> Path:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,6 +14,10 @@ from datetime import datetime, timezone
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.responses import Response
+from starlette.types import Scope
 
 from app.api import arena, datasets, export, history, inference, models, recipes, system, training
 from app.config import get_settings
@@ -21,6 +25,24 @@ from app.core.errors import register_exception_handlers
 from app.db.database import init_db
 
 ALLOWED_ORIGINS = ["http://localhost:5173"]
+
+
+class SPAStaticFiles(StaticFiles):
+    """StaticFiles with an SPA fallback: unknown paths serve index.html.
+
+    Deep links like `/training` or `/datasets` are client-side routes, so a
+    404 from the static lookup falls back to `index.html`. API paths are
+    explicitly exempt: an unknown `/api/...` request re-raises the original
+    404 so it keeps returning JSON instead of the SPA shell.
+    """
+
+    async def get_response(self, path: str, scope: Scope) -> Response:
+        try:
+            return await super().get_response(path, scope)
+        except StarletteHTTPException as exc:
+            if exc.status_code == 404 and not path.startswith(("api/", "ws/")):
+                return await super().get_response("index.html", scope)
+            raise
 
 
 async def reap_orphans() -> None:
@@ -103,6 +125,14 @@ def create_app() -> FastAPI:
         history,
     ):
         app.include_router(router_module.router, prefix="/api/v1")
+
+    # Production: serve the built frontend (see Settings.static_dir). Mounted
+    # AFTER all routers so every registered route (REST and WS) wins over the
+    # static catch-all. When index.html is absent — the dev/test default —
+    # nothing is mounted and the app behaves exactly as before.
+    static_dir = get_settings().static_dir
+    if (static_dir / "index.html").is_file():
+        app.mount("/", SPAStaticFiles(directory=static_dir, html=True), name="frontend")
 
     return app
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = [
     "datasets",
 ]
 
+[project.scripts]
+mlxlf = "app.cli:main"
+
 [project.optional-dependencies]
 mlx = [
     "mlx-lm-lora==3.0.0",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -8,6 +8,10 @@ from app.config import get_settings
 @pytest.fixture
 def data_dir(tmp_path, monkeypatch):
     monkeypatch.setenv("MLXLF_DATA_DIR", str(tmp_path))
+    # Point the static dir at a path that doesn't exist so tests are hermetic
+    # even when the repo has a built `frontend/dist` (which create_app would
+    # otherwise auto-detect and mount). Static-serving tests override this.
+    monkeypatch.setenv("MLXLF_STATIC_DIR", str(tmp_path / "no-static"))
     get_settings.cache_clear()
     yield tmp_path
     get_settings.cache_clear()

--- a/backend/tests/integration/test_static_frontend.py
+++ b/backend/tests/integration/test_static_frontend.py
@@ -1,0 +1,76 @@
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.config import get_settings
+
+INDEX_HTML = "<!doctype html><html><body>spa-index</body></html>"
+APP_JS = "console.log('spa');"
+
+
+@pytest_asyncio.fixture
+async def static_client(data_dir, tmp_path, monkeypatch):
+    """Client for an app created with a populated MLXLF_STATIC_DIR."""
+    static_dir = tmp_path / "dist"
+    (static_dir / "assets").mkdir(parents=True)
+    (static_dir / "index.html").write_text(INDEX_HTML)
+    (static_dir / "assets" / "app.js").write_text(APP_JS)
+
+    monkeypatch.setenv("MLXLF_STATIC_DIR", str(static_dir))
+    get_settings.cache_clear()
+
+    from app.main import create_app
+
+    application = create_app()
+    async with application.router.lifespan_context(application):
+        transport = ASGITransport(app=application)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_root_returns_404_without_static_dir(client):
+    # Default dev/test behavior: no built frontend, nothing mounted at "/".
+    response = await client.get("/")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_root_serves_index_html(static_client):
+    response = await static_client.get("/")
+    assert response.status_code == 200
+    assert response.text == INDEX_HTML
+    assert response.headers["content-type"].startswith("text/html")
+
+
+@pytest.mark.asyncio
+async def test_asset_served_with_content_type(static_client):
+    response = await static_client.get("/assets/app.js")
+    assert response.status_code == 200
+    assert response.text == APP_JS
+    assert "javascript" in response.headers["content-type"]
+
+
+@pytest.mark.asyncio
+async def test_deep_link_falls_back_to_index_html(static_client):
+    response = await static_client.get("/training")
+    assert response.status_code == 200
+    assert response.text == INDEX_HTML
+    assert response.headers["content-type"].startswith("text/html")
+
+
+@pytest.mark.asyncio
+async def test_unknown_api_path_returns_json_404_not_index(static_client):
+    response = await static_client.get("/api/v1/nonexistent")
+    assert response.status_code == 404
+    assert response.headers["content-type"] == "application/json"
+    assert response.json() == {"detail": "Not Found"}
+
+
+@pytest.mark.asyncio
+async def test_api_routes_still_work_with_static_mount(static_client):
+    response = await static_client.get("/api/v1/system/health")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/json"
+    assert response.json()["status"] == "ok"

--- a/backend/tests/unit/test_cli.py
+++ b/backend/tests/unit/test_cli.py
@@ -1,0 +1,45 @@
+from unittest.mock import patch
+
+from app.cli import main
+
+
+def _run(argv):
+    with (
+        patch("app.cli.uvicorn.run") as mock_run,
+        patch("app.cli.webbrowser.open") as mock_open,
+    ):
+        main(argv)
+    return mock_run, mock_open
+
+
+def test_defaults_open_browser_and_forward_host_port(data_dir, capsys):
+    mock_run, mock_open = _run([])
+    mock_open.assert_called_once_with("http://127.0.0.1:8000")
+    mock_run.assert_called_once_with("app.main:app", host="127.0.0.1", port=8000)
+    # data_dir fixture points MLXLF_STATIC_DIR at a missing dir -> API-only hint.
+    assert "serving API only" in capsys.readouterr().out
+
+
+def test_no_browser_suppresses_open(data_dir):
+    mock_run, mock_open = _run(["--no-browser"])
+    mock_open.assert_not_called()
+    mock_run.assert_called_once_with("app.main:app", host="127.0.0.1", port=8000)
+
+
+def test_custom_host_and_port_forwarded(data_dir):
+    mock_run, mock_open = _run(["--host", "0.0.0.0", "--port", "8123"])
+    mock_open.assert_called_once_with("http://0.0.0.0:8123")
+    mock_run.assert_called_once_with("app.main:app", host="0.0.0.0", port=8123)
+
+
+def test_no_hint_when_static_dir_populated(data_dir, tmp_path, monkeypatch, capsys):
+    static_dir = tmp_path / "dist"
+    static_dir.mkdir()
+    (static_dir / "index.html").write_text("<html></html>")
+    monkeypatch.setenv("MLXLF_STATIC_DIR", str(static_dir))
+
+    from app.config import get_settings
+
+    get_settings.cache_clear()
+    _run(["--no-browser"])
+    assert "serving API only" not in capsys.readouterr().out

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,8 +12,9 @@ affect the contract.
 
 | Module | Responsibility |
 | --- | --- |
-| `main.py` | FastAPI app factory: mounts every router under `/api/v1`, wires the SQLite lifecycle (`init_db` + orphan reaping on startup, `JobManager.shutdown()` on shutdown), registers the standard error-shape exception handlers, CORS for the Vite dev origin. |
-| `config.py` | `Settings` (pydantic-settings, env prefix `MLXLF_`) — the single source of the data directory and its derived subpaths (`models_dir`, `datasets_dir`, `runs_dir`, `exports_dir`, `cache_dir`, `db_path`). |
+| `main.py` | FastAPI app factory: mounts every router under `/api/v1`, wires the SQLite lifecycle (`init_db` + orphan reaping on startup, `JobManager.shutdown()` on shutdown), registers the standard error-shape exception handlers, CORS for the Vite dev origin. If `Settings.static_dir` contains a built frontend (`index.html`), it is mounted at `/` *after* all routers via `SPAStaticFiles` — a `StaticFiles` subclass whose 404s fall back to `index.html` so deep links (`/training`, `/datasets`, …) serve the SPA shell, while unknown `/api/...` paths still return the plain JSON 404. Absent the build (dev/tests/CI), nothing is mounted. |
+| `config.py` | `Settings` (pydantic-settings, env prefix `MLXLF_`) — the single source of the data directory and its derived subpaths (`models_dir`, `datasets_dir`, `runs_dir`, `exports_dir`, `cache_dir`, `db_path`), plus `static_dir` (defaults to the repo's `frontend/dist`). |
+| `cli.py` | `mlxlf` console entry point (`[project.scripts]`): argparse (`--host`, `--port`, `--no-browser`), opens the browser, then runs uvicorn on `app.main:app`. mlx-free at import time — `app.main` is loaded lazily via uvicorn's import string. |
 | `deps.py` | Shared FastAPI dependencies: `get_current_user` (no-op today, exists so auth can be added later without touching routers), `get_settings`, `get_db`. |
 | `api/system.py` | `GET /system/health`, `GET /system/stats` (memory/disk via `psutil`, active run id, data dir). |
 | `api/models.py` | Model registry routes — local list, HF search proxy, download start/list, delete, `WS /ws/downloads/{download_id}`. Thin wrapper over `services/model_registry.py`. |


### PR DESCRIPTION
Closes #14.

Until now the app only ran via `make dev` (uvicorn --reload + Vite dev server) — there was no way to run it as a single shipped unit. Now: `make run` (or `make build` once, then `cd backend && uv run mlxlf`) starts one process that serves both the API and the built UI, and opens the browser.

## Static serving (`backend/app/main.py`, `config.py`)

- New `static_dir` setting (`MLXLF_STATIC_DIR`), defaulting to the repo's `frontend/dist`, so a git clone works with zero config.
- If `static_dir/index.html` exists, `create_app()` mounts it at `/` **after** all routers via `SPAStaticFiles` — a `StaticFiles` subclass whose 404s fall back to `index.html`, so client-side routes (`/training`, `/datasets`, …) serve the SPA shell. Unknown `/api/...` and `/ws/...` paths re-raise instead, keeping today's JSON 404 for API consumers.
- Without a build present (dev/tests/CI) nothing is mounted — behavior is byte-for-byte unchanged, CORS untouched. The test conftest pins `MLXLF_STATIC_DIR` to a nonexistent path so the suite stays hermetic even when a local `frontend/dist` exists.
- No `/api/v1` contract changes (`docs/api.md` untouched; `docs/architecture.md` module map updated).

## Single-command startup (`backend/app/cli.py`)

- `mlxlf` console script (`[project.scripts]`): `--host` (default 127.0.0.1), `--port` (default 8000), `--no-browser`; opens the browser then runs uvicorn on `app.main:app` (no reload). If the bundle is missing it prints a "run `make build` first — serving API only" hint but still starts.
- mlx-free at import time (`app.main` loads lazily via uvicorn's import string); `uv.lock` unchanged.
- `make run` chains `build` + `mlxlf`; README gains a "Production / single-command run" section and an `MLXLF_STATIC_DIR` config row.

## Tests (+10)

- Integration (`test_static_frontend.py`): no static dir → `/` 404 as before; with a populated dir → `/` and deep link `/training` serve index.html, `/assets/app.js` served with the right content type, `/api/v1/nonexistent` stays a JSON 404, `/api/v1/system/health` stays JSON 200.
- Unit (`test_cli.py`): browser opened by default / suppressed with `--no-browser`, host/port forwarded to uvicorn, API-only hint logic.

## Verification

- `make test`: backend **413 passed** (+10), frontend **193 passed**; `make lint` clean.
- **Live smoke** after `make build`: `uv run mlxlf --no-browser --port 8123` → `/` and `/training` return the real Vite index.html, `/assets/index-*.js` `text/javascript`, `/api/v1/system/health` JSON 200, `/api/v1/nope` JSON 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UEysgYYG512HSnoKf5cgm

---
_Generated by [Claude Code](https://claude.ai/code/session_014UEysgYYG512HSnoKf5cgm)_