### PR TITLE
Dependency version bounds + contract docs for HF 502s and insufficient-disk 409 (issues #15, #16)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,9 @@
 # mlx-lora-finetuner
 
-Apple Silicon üzerinde MLX ile LoRA fine-tuning yapan bir Python uygulaması.
-(Proje yeni — yapı oturdukça bu dosyayı güncelle.)
+Apple Silicon üzerinde mlx-lm-lora ile LoRA/DoRA/full fine-tuning yapan yerel
+web uygulaması: FastAPI backend + React SPA (model indirme, veri kümesi
+yönetimi, SFT/DPO/ORPO/CPO/GRPO/FTPO eğitimi, chat/arena, GGUF/Ollama export).
+Tek komut çalıştırma: `make run` (`mlxlf`).
 
 ## Çalışma şekli
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -3,19 +3,22 @@ name = "mlx-lora-finetuner-backend"
 version = "0.1.0"
 description = "MLX ile LoRA fine-tuning yapan uygulamanın FastAPI backend'i"
 requires-python = ">=3.11"
+# Bounds policy: lower bound = the minor we develop/lock against, upper
+# bound = the next major, so a `uv lock` refresh fails loudly instead of
+# silently pulling a breaking major (the mlx extra stays pinned exactly).
 dependencies = [
-    "fastapi",
-    "uvicorn[standard]",
-    "pydantic>=2",
-    "pydantic-settings",
-    "aiosqlite",
-    "huggingface_hub",
-    "psutil",
-    "jinja2",
-    "python-multipart",
-    "pypdf",
-    "python-docx",
-    "datasets",
+    "fastapi>=0.139,<1",
+    "uvicorn[standard]>=0.51,<1",
+    "pydantic>=2.13,<3",
+    "pydantic-settings>=2.14,<3",
+    "aiosqlite>=0.22,<1",
+    "huggingface_hub>=1.23,<2",
+    "psutil>=7.2,<8",
+    "jinja2>=3.1,<4",
+    "python-multipart>=0.0.32,<1",
+    "pypdf>=6.14,<7",
+    "python-docx>=1.2,<2",
+    "datasets>=5.0,<6",
 ]
 
 [project.scripts]
@@ -29,10 +32,10 @@ mlx = [
 
 [dependency-groups]
 dev = [
-    "pytest",
-    "pytest-asyncio",
-    "httpx",
-    "ruff",
+    "pytest>=9.1,<10",
+    "pytest-asyncio>=1.4,<2",
+    "httpx>=0.28,<1",
+    "ruff>=0.15,<1",
 ]
 
 [build-system]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -957,29 +957,29 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiosqlite" },
-    { name = "datasets" },
-    { name = "fastapi" },
-    { name = "huggingface-hub" },
-    { name = "jinja2" },
+    { name = "aiosqlite", specifier = ">=0.22,<1" },
+    { name = "datasets", specifier = ">=5.0,<6" },
+    { name = "fastapi", specifier = ">=0.139,<1" },
+    { name = "huggingface-hub", specifier = ">=1.23,<2" },
+    { name = "jinja2", specifier = ">=3.1,<4" },
     { name = "mlx-lm", marker = "extra == 'mlx'", specifier = "==0.31.3" },
     { name = "mlx-lm-lora", marker = "extra == 'mlx'", specifier = "==3.0.0" },
-    { name = "psutil" },
-    { name = "pydantic", specifier = ">=2" },
-    { name = "pydantic-settings" },
-    { name = "pypdf" },
-    { name = "python-docx" },
-    { name = "python-multipart" },
-    { name = "uvicorn", extras = ["standard"] },
+    { name = "psutil", specifier = ">=7.2,<8" },
+    { name = "pydantic", specifier = ">=2.13,<3" },
+    { name = "pydantic-settings", specifier = ">=2.14,<3" },
+    { name = "pypdf", specifier = ">=6.14,<7" },
+    { name = "python-docx", specifier = ">=1.2,<2" },
+    { name = "python-multipart", specifier = ">=0.0.32,<1" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.51,<1" },
 ]
 provides-extras = ["mlx"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "httpx" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "ruff" },
+    { name = "httpx", specifier = ">=0.28,<1" },
+    { name = "pytest", specifier = ">=9.1,<10" },
+    { name = "pytest-asyncio", specifier = ">=1.4,<2" },
+    { name = "ruff", specifier = ">=0.15,<1" },
 ]
 
 [[package]]

--- a/docs/api.md
+++ b/docs/api.md
@@ -55,8 +55,11 @@ Proxy of HF Hub search. Default `author=mlx-community` applied only when `author
 ```json
 {"results": [{"model_id": "...", "downloads": 123, "likes": 4, "size_bytes": null, "downloaded": false}]}
 ```
+→ `502` (code `internal`) when the HF Hub request fails or the Hub is unreachable.
 ### POST /models/download  `{"model_id": "..."}` → `202 {"download_id": "dl_...", "model_id": "..."}`
 409 `conflict` if already downloading. Existing completed model → 409 `conflict`.
+409 `conflict` also when the estimated repo size exceeds free disk space (message
+names the required vs. available bytes).
 ### GET /models/downloads
 ```json
 {"downloads": [{"download_id": "dl_...", "model_id": "...",
@@ -122,6 +125,7 @@ HF Hub dataset search proxy (`HfApi.list_datasets`).
 {"results": [{"dataset_id": "mlx-community/wikisql", "downloads": 1234, "likes": 5, "imported": false}]}
 ```
 `imported` is true when a local dataset was already imported from that HF id.
+→ `502` (code `internal`) when the HF Hub request fails or the Hub is unreachable.
 
 ### POST /datasets/import
 ```json


### PR DESCRIPTION
Closes #15, closes #16 — two small protective changes, one commit each.

## #15 — Dependency version bounds (`c7050f3`)

Every core and dev dependency in `backend/pyproject.toml` was unconstrained, so any `uv lock` refresh could silently pull a breaking major (the npm-side `@emnapi` CI breakage two days ago was this exact failure mode on the other stack). Policy, stated in a comment in the file: **lower bound = the locked minor we develop against, upper bound = the next major**; the `mlx` extra stays pinned exactly (`mlx-lm-lora==3.0.0`, `mlx-lm==0.31.3`).

The relock only rewrote `requires-dist` metadata — **zero package versions changed** (verified against the lock before/after).

## #16 — Contract drift (`9c90d70`)

- `POST /models/download`: the contract documented 409 only for "already downloading / already completed", but the registry also returns `409 conflict` when the estimated repo size exceeds free disk (`model_registry.py`) — now documented.
- Both HF Hub search proxies — `GET /models/search` **and** `GET /datasets/search` (the issue cited only the former; the dataset side has the identical behavior) — return `502` with code `internal` on upstream failure — now documented on both endpoints.
- `CLAUDE.md` intro refreshed: it still described the project as a brand-new, single-language Python app with no frontend; it now reflects the FastAPI + React monorepo, the six training modes, and `make run`.
- (The issue's first checklist item — the stale "Faz 1 sft-only" note — was already resolved in #19.)

## Verification

- `cd backend && uv run pytest`: **413 passed** (one run hit the known pre-existing timing flake in `tests/unit/models/test_cancel.py`; clean on rerun and in isolation)
- `uv run ruff check . ../e2e`: clean
- Docs-only changes otherwise; no API behavior touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UEysgYYG512HSnoKf5cgm

---
_Generated by [Claude Code](https://claude.ai/code/session_014UEysgYYG512HSnoKf5cgm)_