### PR TITLE
GRPO reward-functions editor + checkpoint list in RunMonitor (issues #9, #10)

### DIFF
--- a/backend/app/schemas/training.py
+++ b/backend/app/schemas/training.py
@@ -24,6 +24,21 @@ class TrainType(str, Enum):
     FULL = "full"
 
 
+# mlx-lm-lora 3.0.0's grpo_reward_functions registry. The worker forwards
+# reward_functions verbatim and the library aborts the run on an unknown
+# name, so reject typos at request time (docs/api.md pins the same list).
+# null / [] means the library uses its default set (all five).
+GRPO_REWARD_FUNCTION_NAMES = frozenset(
+    {
+        "r1_accuracy_reward_func",
+        "r1_int_reward_func",
+        "r1_strict_format_reward_func",
+        "r1_soft_format_reward_func",
+        "r1_count_xml",
+    }
+)
+
+
 class JobStatus(str, Enum):
     QUEUED = "queued"
     RUNNING = "running"
@@ -78,6 +93,13 @@ class TrainingConfig(BaseModel):
             raise ValueError("group_size is required for grpo train_mode")
         if self.sft_loss_type is not None and self.train_mode != TrainMode.SFT:
             raise ValueError("sft_loss_type is only accepted for sft train_mode")
+        if self.reward_functions:
+            unknown = sorted(set(self.reward_functions) - GRPO_REWARD_FUNCTION_NAMES)
+            if unknown:
+                raise ValueError(
+                    f"unknown reward_functions: {', '.join(unknown)} "
+                    f"(valid: {', '.join(sorted(GRPO_REWARD_FUNCTION_NAMES))})"
+                )
         if self.train_mode != TrainMode.FTPO:
             ftpo_only = {
                 "lambda_mse_target": self.lambda_mse_target,

--- a/backend/tests/unit/test_schemas.py
+++ b/backend/tests/unit/test_schemas.py
@@ -195,3 +195,28 @@ class TestDatasetFormat:
     def test_member_values(self):
         values = {member.value for member in DatasetFormat}
         assert values == {"chat", "completions", "text", "dpo", "orpo", "grpo", "ftpo"}
+
+
+class TestRewardFunctionValidation:
+    def _grpo(self, **overrides):
+        base = dict(
+            name="my-run",
+            model_id="mlx-community/x",
+            dataset_id="ds_1",
+            train_mode="grpo",
+            group_size=4,
+        )
+        base.update(overrides)
+        return TrainingConfig(**base)
+
+    def test_known_reward_functions_accepted(self):
+        config = self._grpo(reward_functions=["r1_count_xml", "r1_accuracy_reward_func"])
+        assert config.reward_functions == ["r1_count_xml", "r1_accuracy_reward_func"]
+
+    def test_null_and_empty_reward_functions_accepted(self):
+        assert self._grpo(reward_functions=None).reward_functions is None
+        assert self._grpo(reward_functions=[]).reward_functions == []
+
+    def test_unknown_reward_function_rejected_with_valid_list(self):
+        with pytest.raises(ValidationError, match="unknown reward_functions: r1_typo"):
+            self._grpo(reward_functions=["r1_count_xml", "r1_typo"])

--- a/backend/tests/unit/test_training_worker.py
+++ b/backend/tests/unit/test_training_worker.py
@@ -140,12 +140,14 @@ def test_build_worker_args_joins_reward_functions(settings, tmp_path):
     run_dir = tmp_path / "runs" / "run_3"
     run_dir.mkdir(parents=True)
     config = make_config(
-        train_mode="grpo", group_size=4, reward_functions=["accuracy", "format"]
+        train_mode="grpo",
+        group_size=4,
+        reward_functions=["r1_accuracy_reward_func", "r1_count_xml"],
     )
 
     args = worker._build_worker_args(run_dir, config, train_mod=FakeTrainModule)
 
-    assert args.reward_functions == "accuracy,format"
+    assert args.reward_functions == "r1_accuracy_reward_func,r1_count_xml"
     assert args.group_size == 4
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -187,6 +187,10 @@ Conditional validation: `dpo|orpo|cpo` require `beta`; `grpo` requires `group_si
 `sft_loss_type` is only accepted for `sft` (null → library default `nll`).
 `lambda_mse_target`, `tau_mse_target`, `lambda_mse`, `clip_epsilon_logits` are only
 accepted for `ftpo` and are all optional (null → library defaults 0.05 / 1.0 / 0.4 / 2.0).
+`reward_functions` entries must come from the mlx-lm-lora 3.0.0 registry —
+`r1_accuracy_reward_func | r1_int_reward_func | r1_strict_format_reward_func |
+r1_soft_format_reward_func | r1_count_xml` — unknown names → 422; null or `[]` →
+the library's default set (all five).
 Dataset format must be compatible with mode (sft: chat/completions/text; dpo/cpo: dpo;
 orpo: orpo|dpo; grpo: grpo; ftpo: ftpo) → else 422.
 

--- a/frontend/src/components/training/RunMonitor.test.tsx
+++ b/frontend/src/components/training/RunMonitor.test.tsx
@@ -143,6 +143,66 @@ describe('RunMonitor - live run', () => {
     await waitFor(() => expect(screen.getByText('1.230')).toBeInTheDocument())
   })
 
+  it('renders a checkpoint list with step and adapter path, deduping repeated steps', async () => {
+    server.use(
+      http.get('/api/v1/train/jobs/run_1', () =>
+        HttpResponse.json(makeRunSummary({ run_id: 'run_1', status: 'running' })),
+      ),
+      http.get('/api/v1/train/jobs/run_1/metrics', () => HttpResponse.json({ metrics: [] })),
+      http.get('/api/v1/train/jobs/run_1/logs', () => HttpResponse.json({ lines: [] })),
+    )
+
+    renderWithProviders(
+      <RunMonitor
+        runId="run_1"
+        onNewRun={() => {}}
+        WebSocketImpl={MockWebSocket as unknown as typeof WebSocket}
+      />,
+    )
+
+    await screen.findByText('my-run')
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1))
+    act(() => {
+      MockWebSocket.instances[0].open()
+    })
+
+    // No checkpoint section before the first checkpoint frame arrives.
+    expect(screen.queryByText('Checkpoints')).not.toBeInTheDocument()
+
+    act(() => {
+      MockWebSocket.instances[0].emit({
+        type: 'checkpoint',
+        step: 200,
+        adapter_path: '/adapters/run_1/0000200_adapters.safetensors',
+      })
+      MockWebSocket.instances[0].emit({
+        type: 'checkpoint',
+        step: 100,
+        adapter_path: '/adapters/run_1/0000100_adapters.safetensors',
+      })
+      // Duplicate step (reconnect replay) must render once.
+      MockWebSocket.instances[0].emit({
+        type: 'checkpoint',
+        step: 100,
+        adapter_path: '/adapters/run_1/0000100_adapters.safetensors',
+      })
+    })
+
+    await screen.findByText('Checkpoints')
+    const list = screen.getByTestId('checkpoint-list')
+    const rows = within(list).getAllByRole('listitem')
+    expect(rows).toHaveLength(2)
+    // Sorted ascending by step.
+    expect(within(rows[0]).getByText('Step 100')).toBeInTheDocument()
+    expect(
+      within(rows[0]).getByText('/adapters/run_1/0000100_adapters.safetensors'),
+    ).toBeInTheDocument()
+    expect(within(rows[1]).getByText('Step 200')).toBeInTheDocument()
+    expect(
+      within(rows[1]).getByText('/adapters/run_1/0000200_adapters.safetensors'),
+    ).toBeInTheDocument()
+  })
+
   it('shows the Cancel confirm flow and posts to the cancel endpoint', async () => {
     const user = userEvent.setup()
     let cancelled = false

--- a/frontend/src/components/training/RunMonitor.tsx
+++ b/frontend/src/components/training/RunMonitor.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import type { Checkpoint } from '../../stores/trainingStore'
 import { Link } from 'react-router-dom'
 import { useQueryClient } from '@tanstack/react-query'
 import { useCancelRun, useRun, useRunLogs, useRunMetrics } from '../../api/queries/training'
@@ -47,6 +48,7 @@ export function RunMonitor({ runId, WebSocketImpl }: RunMonitorProps) {
   const storeStatus = useTrainingStore((s) => s.status)
   const storeMetrics = useTrainingStore((s) => s.metrics)
   const storeLogLines = useTrainingStore((s) => s.logLines)
+  const storeCheckpoints = useTrainingStore((s) => s.checkpoints)
 
   // Reset mode whenever the viewed run changes.
   useEffect(() => {
@@ -115,6 +117,9 @@ export function RunMonitor({ runId, WebSocketImpl }: RunMonitorProps) {
 
   const metrics: MetricEvent[] = isViewingLiveStore ? storeMetrics : (pastMetrics.data?.metrics ?? [])
   const logLines: string[] = isViewingLiveStore ? storeLogLines : (pastLogs.data?.lines ?? [])
+  // Checkpoints only stream over the live socket; the store keeps them
+  // de-duplicated and sorted ascending by step.
+  const checkpoints: Checkpoint[] = isViewingLiveStore ? storeCheckpoints : []
 
   const lastTrainMetric = useMemo(
     () => [...metrics].reverse().find((m) => m.kind === 'train'),
@@ -199,6 +204,28 @@ export function RunMonitor({ runId, WebSocketImpl }: RunMonitorProps) {
         </Tabs>
       </Card>
 
+      {checkpoints.length > 0 && (
+        <Card title="Checkpoints">
+          <ul className="flex flex-col gap-1.5" data-testid="checkpoint-list">
+            {checkpoints.map((cp) => (
+              <li
+                key={cp.step}
+                className="flex items-center gap-3 rounded-lg border border-border bg-surface-raised px-3 py-1.5 text-sm"
+              >
+                <span className="shrink-0 font-medium text-text">Step {cp.step}</span>
+                <span
+                  className="min-w-0 flex-1 truncate text-right font-mono text-xs text-text-muted"
+                  title={cp.adapter_path}
+                >
+                  {cp.adapter_path}
+                </span>
+                <CopyButton text={cp.adapter_path} label={`Copy adapter path for step ${cp.step}`} />
+              </li>
+            ))}
+          </ul>
+        </Card>
+      )}
+
       <Card>
         <LiveLogViewer lines={logLines} />
       </Card>
@@ -275,6 +302,34 @@ function TerminalPanel({ status, run, logLines }: TerminalPanelProps) {
     <Card title="Training cancelled">
       <p className="text-sm text-text-muted">This run was cancelled.</p>
     </Card>
+  )
+}
+
+// Same copy-to-clipboard pattern as common/CodeBlock, in per-row size.
+function CopyButton({ text, label }: { text: string; label: string }) {
+  const [copied, setCopied] = useState(false)
+
+  async function handleCopy() {
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text)
+        setCopied(true)
+        setTimeout(() => setCopied(false), 1500)
+      }
+    } catch {
+      // Clipboard unavailable or permission denied — nothing further to do.
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      aria-label={label}
+      className="shrink-0 rounded px-2 py-0.5 text-xs text-text-muted hover:bg-surface hover:text-text"
+    >
+      {copied ? 'Copied' : 'Copy'}
+    </button>
   )
 }
 

--- a/frontend/src/components/training/TrainConfigForm.test.tsx
+++ b/frontend/src/components/training/TrainConfigForm.test.tsx
@@ -9,6 +9,7 @@ import { TrainConfigForm } from './TrainConfigForm'
 import { DEFAULT_TRAINING_CONFIG } from './defaults'
 import {
   ftpoDataset,
+  grpoDataset,
   makeRunSummary,
   splitDataset,
   trainingHandlers,
@@ -98,6 +99,139 @@ describe('TrainConfigForm', () => {
     expect(screen.getByLabelText('Temperature')).toHaveValue(0.8)
     expect(screen.getByLabelText('Max completion length')).toHaveValue(512)
     expect(screen.queryByLabelText('Beta')).not.toBeInTheDocument()
+  })
+
+  it('shows the five grpo reward-function checkboxes, all unchecked by default', async () => {
+    const user = userEvent.setup()
+    renderForm()
+    await waitForPickersLoaded()
+
+    expect(screen.queryByText('Reward functions')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('radio', { name: 'GRPO' }))
+
+    expect(screen.getByText('Reward functions')).toBeInTheDocument()
+    const checkboxes = screen.getAllByRole('checkbox')
+    expect(checkboxes).toHaveLength(5)
+    for (const name of [
+      /r1_accuracy_reward_func/,
+      /r1_int_reward_func/,
+      /r1_strict_format_reward_func/,
+      /r1_soft_format_reward_func/,
+      /r1_count_xml/,
+    ]) {
+      expect(screen.getByRole('checkbox', { name })).not.toBeChecked()
+    }
+    expect(screen.getByText('None selected → library default (all five).')).toBeInTheDocument()
+  })
+
+  it('submits reward_functions: null for grpo when no reward function is checked', async () => {
+    const user = userEvent.setup()
+    let capturedBody: unknown = null
+    server.use(
+      http.post('/api/v1/train/jobs', async ({ request }) => {
+        capturedBody = await request.json()
+        return HttpResponse.json(makeRunSummary({ run_id: 'run_captured' }), { status: 201 })
+      }),
+    )
+    const { onCreated } = renderForm()
+    await waitForPickersLoaded()
+
+    await user.click(screen.getByRole('radio', { name: 'GRPO' }))
+    await user.type(screen.getByLabelText('Run name'), 'my-grpo-run')
+    await user.click(screen.getByRole('radio', { name: new RegExp(trainModel.model_id) }))
+    await user.click(screen.getByRole('radio', { name: /my-grpo-data/ }))
+    await user.click(screen.getByRole('button', { name: 'Start training' }))
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith('run_captured'))
+    expect(capturedBody).toMatchObject({
+      train_mode: 'grpo',
+      dataset_id: grpoDataset.dataset_id,
+      reward_functions: null,
+    })
+  })
+
+  it('submits exactly the checked reward functions in registry order, not click order', async () => {
+    const user = userEvent.setup()
+    let capturedBody: unknown = null
+    server.use(
+      http.post('/api/v1/train/jobs', async ({ request }) => {
+        capturedBody = await request.json()
+        return HttpResponse.json(makeRunSummary({ run_id: 'run_captured' }), { status: 201 })
+      }),
+    )
+    const { onCreated } = renderForm()
+    await waitForPickersLoaded()
+
+    await user.click(screen.getByRole('radio', { name: 'GRPO' }))
+    // Click in reverse registry order — the submitted array must still be
+    // registry-ordered (accuracy before count_xml).
+    await user.click(screen.getByRole('checkbox', { name: /r1_count_xml/ }))
+    await user.click(screen.getByRole('checkbox', { name: /r1_accuracy_reward_func/ }))
+
+    await user.type(screen.getByLabelText('Run name'), 'my-grpo-run')
+    await user.click(screen.getByRole('radio', { name: new RegExp(trainModel.model_id) }))
+    await user.click(screen.getByRole('radio', { name: /my-grpo-data/ }))
+    await user.click(screen.getByRole('button', { name: 'Start training' }))
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith('run_captured'))
+    expect(capturedBody).toMatchObject({
+      train_mode: 'grpo',
+      reward_functions: ['r1_accuracy_reward_func', 'r1_count_xml'],
+    })
+  })
+
+  it('unchecking the last reward function goes back to submitting null', async () => {
+    const user = userEvent.setup()
+    let capturedBody: unknown = null
+    server.use(
+      http.post('/api/v1/train/jobs', async ({ request }) => {
+        capturedBody = await request.json()
+        return HttpResponse.json(makeRunSummary({ run_id: 'run_captured' }), { status: 201 })
+      }),
+    )
+    const { onCreated } = renderForm()
+    await waitForPickersLoaded()
+
+    await user.click(screen.getByRole('radio', { name: 'GRPO' }))
+    await user.click(screen.getByRole('checkbox', { name: /r1_int_reward_func/ }))
+    await user.click(screen.getByRole('checkbox', { name: /r1_int_reward_func/ }))
+
+    await user.type(screen.getByLabelText('Run name'), 'my-grpo-run')
+    await user.click(screen.getByRole('radio', { name: new RegExp(trainModel.model_id) }))
+    await user.click(screen.getByRole('radio', { name: /my-grpo-data/ }))
+    await user.click(screen.getByRole('button', { name: 'Start training' }))
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith('run_captured'))
+    expect(capturedBody).toMatchObject({ reward_functions: null })
+  })
+
+  it('clears the reward-function selection when switching grpo → sft (submits null)', async () => {
+    const user = userEvent.setup()
+    let capturedBody: unknown = null
+    server.use(
+      http.post('/api/v1/train/jobs', async ({ request }) => {
+        capturedBody = await request.json()
+        return HttpResponse.json(makeRunSummary({ run_id: 'run_captured' }), { status: 201 })
+      }),
+    )
+    const { onCreated } = renderForm()
+    await waitForPickersLoaded()
+
+    await user.click(screen.getByRole('radio', { name: 'GRPO' }))
+    await user.click(screen.getByRole('checkbox', { name: /r1_accuracy_reward_func/ }))
+    await user.click(screen.getByRole('checkbox', { name: /r1_soft_format_reward_func/ }))
+
+    await user.click(screen.getByRole('radio', { name: 'SFT' }))
+    expect(screen.queryByText('Reward functions')).not.toBeInTheDocument()
+
+    await user.type(screen.getByLabelText('Run name'), 'back-to-sft')
+    await user.click(screen.getByRole('radio', { name: new RegExp(trainModel.model_id) }))
+    await user.click(screen.getByRole('radio', { name: /my-chat-data/ }))
+    await user.click(screen.getByRole('button', { name: 'Start training' }))
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith('run_captured'))
+    expect(capturedBody).toMatchObject({ train_mode: 'sft', reward_functions: null })
   })
 
   it('blocks submit with a beta error when beta is cleared for dpo', async () => {

--- a/frontend/src/components/training/TrainConfigForm.tsx
+++ b/frontend/src/components/training/TrainConfigForm.tsx
@@ -16,6 +16,7 @@ import { useToast } from '../common/Toast'
 import {
   DEFAULT_TRAINING_CONFIG,
   defaultOverridesForMode,
+  GRPO_REWARD_FUNCTIONS,
   LOAD_IN_BITS_OPTIONS,
   LR_SCHEDULE_OPTIONS,
   MODE_OPTIONS,
@@ -59,6 +60,20 @@ export function TrainConfigForm({ onCreated, initialConfig }: TrainConfigFormPro
 
   function updateMode(mode: TrainMode) {
     setConfig((prev) => ({ ...prev, train_mode: mode, ...defaultOverridesForMode(mode) }))
+  }
+
+  function toggleRewardFunction(name: string) {
+    setConfig((prev) => {
+      const selected = new Set(prev.reward_functions ?? [])
+      if (selected.has(name)) {
+        selected.delete(name)
+      } else {
+        selected.add(name)
+      }
+      // Always submit in the fixed registry order, never click order.
+      const ordered = GRPO_REWARD_FUNCTIONS.map((fn) => fn.value).filter((v) => selected.has(v))
+      return { ...prev, reward_functions: ordered.length > 0 ? ordered : null }
+    })
   }
 
   function handleSubmit(event: React.FormEvent) {
@@ -287,6 +302,32 @@ export function TrainConfigForm({ onCreated, initialConfig }: TrainConfigFormPro
               />
             </Field>
           </div>
+          <fieldset className="mt-4">
+            <legend className="mb-2 block text-sm font-medium text-text">Reward functions</legend>
+            <div className="flex flex-col gap-2">
+              {GRPO_REWARD_FUNCTIONS.map((fn) => (
+                <label
+                  key={fn.value}
+                  className="flex items-center gap-2 text-sm text-text"
+                  title={fn.value}
+                >
+                  <input
+                    type="checkbox"
+                    checked={(config.reward_functions ?? []).includes(fn.value)}
+                    onChange={() => toggleRewardFunction(fn.value)}
+                    className="h-4 w-4 accent-accent"
+                  />
+                  <span>
+                    {fn.label}{' '}
+                    <code className="font-mono text-xs text-text-muted">({fn.value})</code>
+                  </span>
+                </label>
+              ))}
+            </div>
+            <p className="mt-2 text-xs text-text-muted">
+              None selected → library default (all five).
+            </p>
+          </fieldset>
         </Card>
       )}
 

--- a/frontend/src/components/training/defaults.ts
+++ b/frontend/src/components/training/defaults.ts
@@ -63,6 +63,7 @@ type ModeSpecificFields = Pick<
   | 'group_size'
   | 'temperature'
   | 'max_completion_length'
+  | 'reward_functions'
   | 'sft_loss_type'
   | 'lambda_mse_target'
   | 'tau_mse_target'
@@ -75,6 +76,7 @@ const MODE_FIELDS_CLEARED: ModeSpecificFields = {
   group_size: null,
   temperature: null,
   max_completion_length: null,
+  reward_functions: null,
   sft_loss_type: null,
   lambda_mse_target: null,
   tau_mse_target: null,
@@ -93,6 +95,17 @@ export function defaultOverridesForMode(mode: TrainMode): ModeSpecificFields {
   // hyperparameters stay null → library defaults 0.05 / 1.0 / 0.4 / 2.0).
   return { ...MODE_FIELDS_CLEARED }
 }
+
+// GRPO reward function registry, pinned by mlx-lm-lora 3.0.0 (see docs/api.md).
+// Array order is the canonical submit order; the backend 422s on unknown names.
+// Nothing selected → `reward_functions: null` → the library uses all five.
+export const GRPO_REWARD_FUNCTIONS: { value: string; label: string }[] = [
+  { value: 'r1_accuracy_reward_func', label: 'Accuracy' },
+  { value: 'r1_int_reward_func', label: 'Integer answer' },
+  { value: 'r1_strict_format_reward_func', label: 'Strict format' },
+  { value: 'r1_soft_format_reward_func', label: 'Soft format' },
+  { value: 'r1_count_xml', label: 'XML tag count' },
+]
 
 export const TRAIN_TYPE_OPTIONS: { value: TrainType; label: string }[] = [
   { value: 'lora', label: 'LoRA' },

--- a/frontend/src/stores/trainingStore.test.ts
+++ b/frontend/src/stores/trainingStore.test.ts
@@ -89,6 +89,28 @@ describe('trainingStore', () => {
     ])
   })
 
+  it('dedupes checkpoint frames by step (reconnect replay), keeping the latest path', () => {
+    const store = useTrainingStore.getState()
+    store.applyWsFrame({ type: 'checkpoint', step: 10, adapter_path: '/adapters/a' })
+    store.applyWsFrame({ type: 'checkpoint', step: 20, adapter_path: '/adapters/b' })
+    // reconnect backfill re-sends step 10
+    store.applyWsFrame({ type: 'checkpoint', step: 10, adapter_path: '/adapters/a-replayed' })
+    const { checkpoints } = useTrainingStore.getState()
+    expect(checkpoints).toEqual([
+      { step: 10, adapter_path: '/adapters/a-replayed' },
+      { step: 20, adapter_path: '/adapters/b' },
+    ])
+  })
+
+  it('keeps checkpoints sorted ascending by step regardless of arrival order', () => {
+    const store = useTrainingStore.getState()
+    store.applyWsFrame({ type: 'checkpoint', step: 300, adapter_path: '/adapters/c' })
+    store.applyWsFrame({ type: 'checkpoint', step: 100, adapter_path: '/adapters/a' })
+    store.applyWsFrame({ type: 'checkpoint', step: 200, adapter_path: '/adapters/b' })
+    const { checkpoints } = useTrainingStore.getState()
+    expect(checkpoints.map((c) => c.step)).toEqual([100, 200, 300])
+  })
+
   it('reset(runId) clears metrics/logLines/checkpoints/error and sets the new runId', () => {
     const store = useTrainingStore.getState()
     store.applyWsFrame({ type: 'metric', data: makeMetric(1, 'train') })

--- a/frontend/src/stores/trainingStore.ts
+++ b/frontend/src/stores/trainingStore.ts
@@ -53,9 +53,14 @@ export const useTrainingStore = create<TrainingState>((set) => ({
         })
         break
       case 'checkpoint':
-        set((state) => ({
-          checkpoints: [...state.checkpoints, { step: frame.step, adapter_path: frame.adapter_path }],
-        }))
+        // De-dup by step (reconnect backfill can replay checkpoint frames),
+        // keeping the latest frame's path, sorted ascending by step.
+        set((state) => {
+          const checkpoints = state.checkpoints.filter((c) => c.step !== frame.step)
+          checkpoints.push({ step: frame.step, adapter_path: frame.adapter_path })
+          checkpoints.sort((a, b) => a.step - b.step)
+          return { checkpoints }
+        })
         break
     }
   },

--- a/frontend/src/test/handlers/training.ts
+++ b/frontend/src/test/handlers/training.ts
@@ -36,6 +36,16 @@ export const ftpoDataset: DatasetInfo = {
   created_at: '2026-07-12T10:00:00Z',
 }
 
+export const grpoDataset: DatasetInfo = {
+  dataset_id: 'ds_grpo',
+  name: 'my-grpo-data',
+  format: 'grpo',
+  path: '/datasets/ds_grpo',
+  row_count: 150,
+  splits: { train: 120, valid: 15, test: 15 },
+  created_at: '2026-07-12T10:00:00Z',
+}
+
 export const unsplitDataset: DatasetInfo = {
   dataset_id: 'ds_2',
   name: 'no-splits-yet',
@@ -96,7 +106,7 @@ export function makeRunSummary(overrides: Partial<RunSummary> = {}): RunSummary 
 
 export const trainingHandlers = [
   http.get('/api/v1/datasets', () =>
-    HttpResponse.json({ datasets: [splitDataset, ftpoDataset, unsplitDataset] }),
+    HttpResponse.json({ datasets: [splitDataset, ftpoDataset, grpoDataset, unsplitDataset] }),
   ),
   http.get('/api/v1/train/jobs/:runId/metrics', () => HttpResponse.json({ metrics: [] })),
   http.get('/api/v1/train/jobs/:runId/logs', () => HttpResponse.json({ lines: [] })),


### PR DESCRIPTION
Closes #9, closes #10 — four commits: contract first, then backend validation, then the two UI features.

## #9 — GRPO reward-functions editor (`8fafeba`, `93cd059`, `7461fdc`)

`reward_functions` was in the contract and typed on the frontend but had no UI — always submitted `null`, so GRPO runs could never configure reward functions. And a typo'd name would have sailed through the API only to abort the run inside mlx-lm-lora.

- **Contract** (`8fafeba`): docs/api.md pins the five valid registry names from mlx-lm-lora 3.0.0 (`r1_accuracy_reward_func`, `r1_int_reward_func`, `r1_strict_format_reward_func`, `r1_soft_format_reward_func`, `r1_count_xml`; verified against the library source) — unknown names → 422; null/`[]` → the library's default set (all five).
- **Backend** (`93cd059`): `TrainingConfig` validates entries against that set and names the invalid ones in the 422.
- **UI** (`7461fdc`): the GRPO card gains a "Reward functions" checkbox fieldset (friendly labels, raw names visible). Nothing checked → `null` with a "None selected → library default (all five)" hint; selections submit in fixed registry order regardless of click order; leaving grpo clears the selection (`MODE_FIELDS_CLEARED` — it was **not** previously cleared, so a mode switch would have tripped the new 422).

## #10 — Checkpoint list in RunMonitor (`efafff9`)

Checkpoint WS frames were accumulated in the training store but never rendered — users had no visibility into intermediate adapters. RunMonitor now shows a "Checkpoints" card (between charts and log viewer) once frames arrive: "Step N" + middle-truncated mono adapter path with a per-row copy button. The store de-dups by step on reconnect replay (keeping the latest path) and keeps the list sorted ascending. Live-view only by design — the contract has no REST endpoint for past runs' checkpoints.

## Tests

+11: 3 schema (valid/empty/unknown reward names, 422 message lists valid set), 1 worker-args (updated to real registry names — the old test's fake names are now correctly rejected), 5 form (checkbox rendering, null default, registry-order submit, uncheck-to-null, mode-switch clearing), 1 RunMonitor (out-of-order + duplicate frames → sorted unique rows), 2 store (de-dup keeping latest path, ascending sort).

## Verification

- `make test`: backend **416 passed**, frontend **201 passed**
- `make lint` clean; `make build` succeeds (pre-existing chunk-size notice only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UEysgYYG512HSnoKf5cgm

---
_Generated by [Claude Code](https://claude.ai/code/session_014UEysgYYG512HSnoKf5cgm)_