### PR TITLE
Align weekly-maintenance action versions with ci.yml (supersedes #41–#45)

### DIFF
--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -19,22 +19,22 @@ jobs:
   health:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
           enable-cache: true
           cache-dependency-glob: backend/uv.lock
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
           cache: "npm"
@@ -66,7 +66,7 @@ jobs:
   upstream-versions:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Compare pinned mlx versions against PyPI
         id: check
@@ -93,7 +93,7 @@ jobs:
 
       - name: Open (or skip duplicate) upstream-version issue
         if: steps.check.outputs.stale != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           STALE: ${{ steps.check.outputs.stale }}
         with:


### PR DESCRIPTION
`weekly-maintenance.yml` was authored from `ci.yml` **before** last week's dependabot action bumps merged, so it still pinned the old majors — which is why dependabot immediately opened five more PRs (#41–#45) targeting just that file.

One commit bumps all of them to the versions `ci.yml` already runs green with — `checkout@v7`, `setup-uv@v7`, `setup-python@v6`, `setup-node@v7` — plus `github-script@v9` (only used here; v9 keeps the same `github.rest.*` API, just a newer runtime).

**After merging:** dependabot auto-closes #41–#45 on its next check since the dependencies are no longer outdated (they can also be closed manually right away).

YAML validated; the workflow itself only runs on schedule/manual dispatch, so the next Monday run (or a manual *Run workflow*) is the live verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UEysgYYG512HSnoKf5cgm

---
_Generated by [Claude Code](https://claude.ai/code/session_014UEysgYYG512HSnoKf5cgm)_