### PR TITLE
Export and load training configs as YAML

### DIFF
--- a/backend/app/api/training.py
+++ b/backend/app/api/training.py
@@ -9,18 +9,22 @@ from __future__ import annotations
 import asyncio
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, Depends, File, Response, UploadFile, WebSocket, WebSocketDisconnect
 from pydantic import BaseModel
 
-from app.core.errors import NotFoundError
+from app.core.errors import NotFoundError, ValidationAppError
 from app.core.ws import get_ws_manager
 from app.deps import get_current_user
 from app.schemas.training import JobStatus, MetricEvent, RunSummary, TrainingConfig
+from app.services.config_yaml import parse_config_yaml, render_config_yaml
 from app.training.manager import JobManager, get_job_manager
 
 router = APIRouter(dependencies=[Depends(get_current_user)])
 
 TERMINAL_STATUSES = {JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.CANCELLED}
+
+# A config export is a few KiB of YAML; anything bigger than this is not one.
+MAX_CONFIG_IMPORT_BYTES = 256 * 1024
 
 
 class RunSummaryListResponse(BaseModel):
@@ -90,6 +94,31 @@ async def get_train_job_logs(
 ) -> LogsResponse:
     lines = await manager.get_logs(run_id, tail=tail)
     return LogsResponse(lines=lines)
+
+
+@router.get("/train/jobs/{run_id}/config.yaml")
+async def get_train_job_config_yaml(
+    run_id: str,
+    manager: Annotated[JobManager, Depends(get_job_manager)],
+) -> Response:
+    run = await manager.get_run(run_id)  # NotFoundError -> 404, as GET /train/jobs/{run_id}
+    return Response(
+        content=render_config_yaml(run),
+        media_type="application/x-yaml",
+        headers={"Content-Disposition": f'attachment; filename="{run_id}-config.yaml"'},
+    )
+
+
+@router.post("/train/configs/import", response_model=TrainingConfig)
+async def import_train_config(file: UploadFile = File(...)) -> TrainingConfig:
+    # Read one byte past the cap so an oversize upload is detected without
+    # buffering an arbitrarily large body.
+    raw = await file.read(MAX_CONFIG_IMPORT_BYTES + 1)
+    if len(raw) > MAX_CONFIG_IMPORT_BYTES:
+        raise ValidationAppError(
+            f"uploaded config file is too large (max {MAX_CONFIG_IMPORT_BYTES // 1024} KiB)"
+        )
+    return parse_config_yaml(raw)
 
 
 async def _watch_for_disconnect(websocket: WebSocket) -> None:

--- a/backend/app/services/config_yaml.py
+++ b/backend/app/services/config_yaml.py
@@ -1,0 +1,112 @@
+"""YAML config export/import (docs/api.md: GET /train/jobs/{run_id}/config.yaml,
+POST /train/configs/import).
+
+Pure yaml+pydantic — no mlx imports, safe to load on the Linux CI runner.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from importlib.metadata import PackageNotFoundError, version
+
+import yaml
+from pydantic import ValidationError
+
+from app.core.errors import ValidationAppError
+from app.schemas.training import RunSummary, TrainingConfig
+
+# The one and only supported document schema version. Bump when the document
+# layout (not the TrainingConfig fields — those validate themselves) changes.
+CONFIG_SCHEMA_VERSION = 1
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _app_version() -> str:
+    try:
+        return version("mlx-lora-finetuner-backend")
+    except PackageNotFoundError:
+        return "0.1.0"
+
+
+def _mlx_lm_lora_version() -> str | None:
+    try:
+        return version("mlx-lm-lora")
+    except Exception:
+        return None
+
+
+def _format_pydantic_error(exc: ValidationError) -> str:
+    parts = []
+    for err in exc.errors():
+        loc = ".".join(str(part) for part in err["loc"])
+        parts.append(f"{loc}: {err['msg']}" if loc else err["msg"])
+    return "; ".join(parts)
+
+
+def render_config_yaml(run: RunSummary) -> str:
+    """Render a run's configuration as the documented YAML export document.
+
+    `config:` carries exactly `TrainingConfig.model_dump(mode="json")` (enums
+    as strings); `metadata:` is informational only and ignored on import.
+    `sort_keys=False` keeps the field order of the models.
+    """
+    document = {
+        "config_schema": CONFIG_SCHEMA_VERSION,
+        "metadata": {
+            "exported_at": _now_iso(),
+            "app_version": _app_version(),
+            "mlx_lm_lora_version": _mlx_lm_lora_version(),
+            "run_id": run.run_id,
+            "status": run.status.value,
+            "final_train_loss": run.final_train_loss,
+            "final_val_loss": run.final_val_loss,
+        },
+        "config": run.config.model_dump(mode="json"),
+    }
+    return yaml.safe_dump(document, sort_keys=False, allow_unicode=True)
+
+
+def parse_config_yaml(raw: bytes | str) -> TrainingConfig:
+    """Parse an exported config document back into a validated TrainingConfig.
+
+    Strict per docs/api.md — every failure is a 422 `validation_error`:
+    - unparsable YAML (or non-UTF-8 bytes) -> "not valid YAML: ...";
+    - document not a mapping, or `config` missing / not a mapping;
+    - `config_schema` != 1 — an absent `config_schema` is also rejected
+      (the contract says it "must be 1", so the exported marker is required);
+    - unknown keys under `config` (named in the message);
+    - then the standard TrainingConfig rules (mode-conditional fields,
+      reward-function names, ...) via pydantic validation.
+    """
+    try:
+        document = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        raise ValidationAppError(f"not valid YAML: {exc}") from exc
+    except UnicodeDecodeError as exc:
+        raise ValidationAppError(f"not valid YAML: {exc}") from exc
+
+    if not isinstance(document, dict):
+        raise ValidationAppError("YAML document must be a mapping")
+
+    schema = document.get("config_schema")
+    if schema != CONFIG_SCHEMA_VERSION:
+        raise ValidationAppError(
+            f"config_schema must be {CONFIG_SCHEMA_VERSION} "
+            f"(got {'none' if schema is None else schema!r})"
+        )
+
+    config = document.get("config")
+    if not isinstance(config, dict):
+        raise ValidationAppError("document must contain a 'config' mapping")
+
+    unknown = sorted(str(key) for key in config if key not in TrainingConfig.model_fields)
+    if unknown:
+        raise ValidationAppError(f"unknown keys under config: {', '.join(unknown)}")
+
+    try:
+        return TrainingConfig.model_validate(config)
+    except ValidationError as exc:
+        raise ValidationAppError(_format_pydantic_error(exc)) from exc

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "pypdf>=6.14,<7",
     "python-docx>=1.2,<2",
     "datasets>=5.0,<6",
+    "pyyaml>=6.0,<7",
 ]
 
 [project.scripts]

--- a/backend/tests/integration/test_config_yaml_api.py
+++ b/backend/tests/integration/test_config_yaml_api.py
@@ -1,0 +1,207 @@
+"""GET /train/jobs/{run_id}/config.yaml + POST /train/configs/import (docs/api.md).
+
+Runs are seeded directly via `RunsRepo` (same pattern as the history API
+tests) — the export endpoint only ever reads the `runs` table.
+"""
+
+from __future__ import annotations
+
+import json
+
+import aiosqlite
+import pytest
+import yaml
+
+from app.config import get_settings
+from app.db.repositories import RunsRepo
+from app.schemas.training import TrainingConfig
+
+SFT_CONFIG = {
+    "name": "my-run",
+    "model_id": "mlx-community/Tiny-1",
+    "dataset_id": "ds_1",
+    "train_mode": "sft",
+}
+
+GRPO_CONFIG = {
+    "name": "grpo-run",
+    "model_id": "mlx-community/Tiny-1",
+    "dataset_id": "ds_grpo",
+    "train_mode": "grpo",
+    "group_size": 4,
+    "temperature": 0.8,
+    "reward_functions": ["r1_accuracy_reward_func", "r1_count_xml"],
+}
+
+FTPO_CONFIG = {
+    "name": "ftpo-run",
+    "model_id": "mlx-community/Tiny-1",
+    "dataset_id": "ds_ftpo",
+    "train_mode": "ftpo",
+    "lambda_mse_target": 0.5,
+    "tau_mse_target": 1.0,
+    "lambda_mse": 0.1,
+    "clip_epsilon_logits": 2.0,
+}
+
+
+async def _seed_run(run_id: str, config: dict, status: str = "completed") -> None:
+    settings = get_settings()
+    async with aiosqlite.connect(settings.db_path) as conn:
+        repo = RunsRepo(conn)
+        await repo.insert(
+            run_id=run_id,
+            name=config["name"],
+            status=status,
+            config_json=json.dumps(config),
+            model_id=config["model_id"],
+            dataset_id=config["dataset_id"],
+            train_mode=config["train_mode"],
+            created_at="2026-07-19T00:00:00Z",
+        )
+        if status == "completed":
+            await repo.finish(
+                run_id,
+                status,
+                finished_at="2026-07-19T00:05:00Z",
+                final_train_loss=1.23,
+                final_val_loss=1.31,
+            )
+
+
+def _import_files(content: bytes) -> dict:
+    return {"file": ("config.yaml", content, "application/x-yaml")}
+
+
+# ------------------------------------------------------------------ export
+
+
+@pytest.mark.asyncio
+async def test_export_yaml_document_and_headers(client):
+    await _seed_run("run_sft", SFT_CONFIG)
+
+    resp = await client.get("/api/v1/train/jobs/run_sft/config.yaml")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("application/x-yaml")
+    disposition = resp.headers["content-disposition"]
+    assert "attachment" in disposition
+    assert "run_sft-config.yaml" in disposition
+
+    document = yaml.safe_load(resp.text)
+    assert document["config_schema"] == 1
+    metadata = document["metadata"]
+    for key in (
+        "exported_at",
+        "app_version",
+        "mlx_lm_lora_version",
+        "run_id",
+        "status",
+        "final_train_loss",
+        "final_val_loss",
+    ):
+        assert key in metadata
+    assert metadata["run_id"] == "run_sft"
+    assert metadata["status"] == "completed"
+    assert metadata["final_train_loss"] == 1.23
+    assert document["config"] == TrainingConfig.model_validate(SFT_CONFIG).model_dump(mode="json")
+
+
+@pytest.mark.asyncio
+async def test_export_unknown_run_returns_404(client):
+    resp = await client.get("/api/v1/train/jobs/run_missing/config.yaml")
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "not_found"
+
+
+# -------------------------------------------------------------- round trip
+
+
+@pytest.mark.parametrize(
+    ("run_id", "config"),
+    [("run_sft", SFT_CONFIG), ("run_grpo", GRPO_CONFIG), ("run_ftpo", FTPO_CONFIG)],
+    ids=["sft", "grpo", "ftpo"],
+)
+@pytest.mark.asyncio
+async def test_export_import_round_trip(client, run_id, config):
+    await _seed_run(run_id, config)
+
+    exported = await client.get(f"/api/v1/train/jobs/{run_id}/config.yaml")
+    assert exported.status_code == 200
+
+    imported = await client.post(
+        "/api/v1/train/configs/import", files=_import_files(exported.content)
+    )
+    assert imported.status_code == 200
+    assert imported.json() == TrainingConfig.model_validate(config).model_dump(mode="json")
+
+
+# ------------------------------------------------------------------ import
+
+
+@pytest.mark.asyncio
+async def test_import_success_returns_exact_config_json(client):
+    config = TrainingConfig.model_validate(GRPO_CONFIG)
+    document = yaml.safe_dump(
+        {"config_schema": 1, "config": config.model_dump(mode="json")}, sort_keys=False
+    )
+    resp = await client.post(
+        "/api/v1/train/configs/import", files=_import_files(document.encode())
+    )
+    assert resp.status_code == 200
+    assert resp.json() == config.model_dump(mode="json")
+
+
+async def _assert_import_422(client, content: bytes, fragment: str) -> None:
+    resp = await client.post("/api/v1/train/configs/import", files=_import_files(content))
+    assert resp.status_code == 422
+    error = resp.json()["error"]
+    assert error["code"] == "validation_error"
+    assert fragment in error["message"]
+
+
+@pytest.mark.asyncio
+async def test_import_garbage_bytes_returns_422(client):
+    await _assert_import_422(client, b"\x00\x81\xfe\xff{{{not yaml", "not valid YAML")
+
+
+@pytest.mark.asyncio
+async def test_import_non_mapping_yaml_returns_422(client):
+    await _assert_import_422(client, b"- a\n- b\n", "must be a mapping")
+
+
+@pytest.mark.asyncio
+async def test_import_missing_config_key_returns_422(client):
+    await _assert_import_422(client, b"config_schema: 1\nmetadata: {}\n", "'config' mapping")
+
+
+@pytest.mark.asyncio
+async def test_import_unknown_config_key_named_in_422(client):
+    document = {
+        "config_schema": 1,
+        "config": {**SFT_CONFIG, "totally_bogus_key": 1},
+    }
+    await _assert_import_422(
+        client, yaml.safe_dump(document).encode(), "totally_bogus_key"
+    )
+
+
+@pytest.mark.asyncio
+async def test_import_wrong_config_schema_returns_422(client):
+    document = {"config_schema": 2, "config": dict(SFT_CONFIG)}
+    await _assert_import_422(
+        client, yaml.safe_dump(document).encode(), "config_schema must be 1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_import_config_violating_rules_returns_422(client):
+    document = {"config_schema": 1, "config": {**SFT_CONFIG, "train_mode": "dpo"}}
+    await _assert_import_422(
+        client, yaml.safe_dump(document).encode(), "beta is required"
+    )
+
+
+@pytest.mark.asyncio
+async def test_import_oversize_file_returns_422(client):
+    padding = b"# " + b"x" * (256 * 1024) + b"\n"
+    await _assert_import_422(client, padding, "too large")

--- a/backend/tests/unit/test_config_yaml.py
+++ b/backend/tests/unit/test_config_yaml.py
@@ -1,0 +1,197 @@
+"""Unit tests for app.services.config_yaml (YAML config export/import)."""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from app.core.errors import ValidationAppError
+from app.schemas.training import JobStatus, RunSummary, TrainingConfig
+from app.services.config_yaml import parse_config_yaml, render_config_yaml
+
+
+def _config(**overrides) -> TrainingConfig:
+    base = {
+        "name": "my-run",
+        "model_id": "mlx-community/Tiny-1",
+        "dataset_id": "ds_1",
+        "train_mode": "sft",
+    }
+    base.update(overrides)
+    return TrainingConfig.model_validate(base)
+
+
+def _run(config: TrainingConfig, **overrides) -> RunSummary:
+    base = {
+        "run_id": "run_abc123",
+        "name": config.name,
+        "status": JobStatus.COMPLETED,
+        "config": config,
+        "created_at": "2026-07-19T00:00:00Z",
+        "final_train_loss": 1.23,
+        "final_val_loss": 1.31,
+    }
+    base.update(overrides)
+    return RunSummary.model_validate(base)
+
+
+# ---------------------------------------------------------------- render
+
+
+def test_render_document_shape():
+    run = _run(_config())
+    document = yaml.safe_load(render_config_yaml(run))
+
+    assert document["config_schema"] == 1
+    metadata = document["metadata"]
+    assert set(metadata) == {
+        "exported_at",
+        "app_version",
+        "mlx_lm_lora_version",
+        "run_id",
+        "status",
+        "final_train_loss",
+        "final_val_loss",
+    }
+    assert metadata["run_id"] == "run_abc123"
+    assert metadata["status"] == "completed"
+    assert metadata["final_train_loss"] == 1.23
+    assert metadata["final_val_loss"] == 1.31
+    assert isinstance(metadata["exported_at"], str)
+    assert isinstance(metadata["app_version"], str)
+
+    # config: exactly the TrainingConfig fields, enums as strings.
+    assert document["config"] == run.config.model_dump(mode="json")
+    assert document["config"]["train_mode"] == "sft"
+    assert set(document["config"]) == set(TrainingConfig.model_fields)
+
+
+def test_render_preserves_field_order():
+    text = render_config_yaml(_run(_config()))
+    # sort_keys=False: top-level order is document order, config order is
+    # the model's declaration order.
+    top_level = [line.split(":")[0] for line in text.splitlines() if not line.startswith(" ")]
+    assert top_level == ["config_schema", "metadata", "config"]
+    config_keys = list(yaml.safe_load(text)["config"])
+    assert config_keys[:4] == ["name", "model_id", "dataset_id", "train_mode"]
+
+
+def test_render_null_losses_while_running():
+    run = _run(
+        _config(),
+        status=JobStatus.RUNNING,
+        final_train_loss=None,
+        final_val_loss=None,
+    )
+    document = yaml.safe_load(render_config_yaml(run))
+    assert document["metadata"]["final_train_loss"] is None
+    assert document["metadata"]["final_val_loss"] is None
+    assert document["metadata"]["status"] == "running"
+
+
+# ------------------------------------------------------------ round trip
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        _config(),
+        _config(
+            name="grpo-run",
+            train_mode="grpo",
+            group_size=4,
+            temperature=0.8,
+            max_completion_length=256,
+            reward_functions=["r1_accuracy_reward_func", "r1_count_xml"],
+        ),
+        _config(
+            name="ftpo-run",
+            train_mode="ftpo",
+            lambda_mse_target=0.5,
+            tau_mse_target=1.0,
+            lambda_mse=0.1,
+            clip_epsilon_logits=2.0,
+        ),
+    ],
+    ids=["sft", "grpo", "ftpo"],
+)
+def test_round_trip_export_import_identical(config):
+    text = render_config_yaml(_run(config))
+    assert parse_config_yaml(text) == config
+    # Bytes input round-trips the same way.
+    assert parse_config_yaml(text.encode("utf-8")) == config
+
+
+# --------------------------------------------------------------- parse 422s
+
+
+def _assert_422(raw, fragment: str):
+    with pytest.raises(ValidationAppError) as exc_info:
+        parse_config_yaml(raw)
+    assert exc_info.value.status_code == 422
+    assert fragment in exc_info.value.message
+
+
+def test_parse_garbage_bytes():
+    _assert_422(b"\x00\x81\xfe\xff{{{not yaml", "not valid YAML")
+
+
+def test_parse_invalid_yaml_syntax():
+    _assert_422("config: [unclosed", "not valid YAML")
+
+
+def test_parse_non_mapping_document():
+    _assert_422("- a\n- b\n", "must be a mapping")
+
+
+def test_parse_missing_config_mapping():
+    _assert_422("config_schema: 1\nmetadata: {}\n", "'config' mapping")
+
+
+def test_parse_config_not_a_mapping():
+    _assert_422("config_schema: 1\nconfig: [1, 2]\n", "'config' mapping")
+
+
+def test_parse_wrong_config_schema():
+    _assert_422("config_schema: 2\nconfig: {}\n", "config_schema must be 1")
+
+
+def test_parse_absent_config_schema():
+    _assert_422("config: {}\n", "config_schema must be 1")
+
+
+def test_parse_unknown_config_key_named():
+    text = render_config_yaml(_run(_config()))
+    document = yaml.safe_load(text)
+    document["config"]["not_a_field"] = 1
+    document["config"]["also_bogus"] = 2
+    with pytest.raises(ValidationAppError) as exc_info:
+        parse_config_yaml(yaml.safe_dump(document))
+    assert "unknown keys under config" in exc_info.value.message
+    assert "not_a_field" in exc_info.value.message
+    assert "also_bogus" in exc_info.value.message
+
+
+def test_parse_metadata_ignored():
+    document = {
+        "config_schema": 1,
+        "metadata": {"status": "failed", "nonsense": True},
+        "config": _config().model_dump(mode="json"),
+    }
+    assert parse_config_yaml(yaml.safe_dump(document)) == _config()
+
+
+def test_parse_training_config_rules_enforced():
+    document = {
+        "config_schema": 1,
+        "config": {
+            "name": "bad",
+            "model_id": "m",
+            "dataset_id": "d",
+            "train_mode": "dpo",  # beta missing -> model_validator error
+        },
+    }
+    with pytest.raises(ValidationAppError) as exc_info:
+        parse_config_yaml(yaml.safe_dump(document))
+    assert exc_info.value.status_code == 422
+    assert "beta is required" in exc_info.value.message

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -938,6 +938,7 @@ dependencies = [
     { name = "pypdf" },
     { name = "python-docx" },
     { name = "python-multipart" },
+    { name = "pyyaml" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -970,6 +971,7 @@ requires-dist = [
     { name = "pypdf", specifier = ">=6.14,<7" },
     { name = "python-docx", specifier = ">=1.2,<2" },
     { name = "python-multipart", specifier = ">=0.0.32,<1" },
+    { name = "pyyaml", specifier = ">=6.0,<7" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.51,<1" },
 ]
 provides-extras = ["mlx"]

--- a/docs/api.md
+++ b/docs/api.md
@@ -213,6 +213,34 @@ orpo: orpo|dpo; grpo: grpo; ftpo: ftpo) → else 422.
 `{"metrics": [MetricEvent]}` — persisted metrics for backfill/history.
 ### GET /train/jobs/{run_id}/logs?tail=200 → `{"lines": ["..."]}`
 
+### GET /train/jobs/{run_id}/config.yaml
+Downloads the run's full configuration as YAML (`Content-Type: application/x-yaml`,
+`Content-Disposition: attachment`). Document shape:
+```yaml
+config_schema: 1
+metadata:            # informational only — ignored on import
+  exported_at: "..."
+  app_version: "0.1.0"
+  mlx_lm_lora_version: "3.0.0"
+  run_id: "run_..."
+  status: "completed"
+  final_train_loss: 1.23    # null while running
+  final_val_loss: 1.31
+config:              # exactly the TrainingConfig fields (see above)
+  name: "my-run"
+  model_id: "mlx-community/..."
+  # ...
+```
+404 if the run is unknown.
+
+### POST /train/configs/import — multipart: `file` (.yaml/.yml)
+Parses and validates an exported config document → `200 TrainingConfig` (JSON),
+ready to prefill the train form. `metadata` is ignored; `config_schema` must be `1`.
+Validation is STRICT: unparsable YAML, a missing `config` mapping, or any unknown
+key under `config` → 422 `validation_error` naming the offending keys, in addition
+to all standard TrainingConfig rules (mode-conditional fields, reward-function
+names, format compatibility is checked later at job submit).
+
 ### MetricEvent
 ```json
 {"run_id": "run_...", "step": 10, "kind": "train",

--- a/frontend/src/api/queries/training.ts
+++ b/frontend/src/api/queries/training.ts
@@ -66,6 +66,25 @@ export function useRunMetrics(runId: string, afterStep = 0, kind?: 'train' | 'va
   })
 }
 
+/**
+ * Same-origin URL for a run's YAML config export (docs/api.md). Served with
+ * `Content-Disposition: attachment`, so a plain anchor triggers a download —
+ * the dev server proxies /api to the backend, no fetch needed.
+ */
+export function runConfigYamlUrl(runId: string): string {
+  return `/api/v1/train/jobs/${encodeURIComponent(runId)}/config.yaml`
+}
+
+export function useImportTrainingConfig() {
+  return useMutation({
+    mutationFn: (file: File) => {
+      const formData = new FormData()
+      formData.set('file', file)
+      return apiClient.post<TrainingConfig>('/train/configs/import', formData)
+    },
+  })
+}
+
 export function useRunLogs(runId: string, tail = 200) {
   return useQuery({
     queryKey: queryKeys.training.logs(runId, tail),

--- a/frontend/src/components/history/RunDetailPanel.tsx
+++ b/frontend/src/components/history/RunDetailPanel.tsx
@@ -10,6 +10,7 @@ import { Field } from '../common/Field'
 import { LossChart } from '../charts/LossChart'
 import { LRChart } from '../charts/LRChart'
 import { MemoryChart } from '../charts/MemoryChart'
+import { ExportConfigLink } from '../training/ExportConfigLink'
 import { ConfigViewer } from './ConfigViewer'
 import { ConfigDiff } from './ConfigDiff'
 import type { RunSummary } from '../../api/types'
@@ -56,9 +57,12 @@ export function RunDetailPanel({ run, otherRuns }: RunDetailPanelProps) {
           <p className="text-xs text-text-muted">{run.run_id}</p>
         </div>
         <div className="flex flex-col items-end gap-1">
-          <Button size="sm" onClick={handleClone} loading={cloneRun.isPending}>
-            Clone
-          </Button>
+          <div className="flex items-center gap-2">
+            <ExportConfigLink runId={run.run_id} />
+            <Button size="sm" onClick={handleClone} loading={cloneRun.isPending}>
+              Clone
+            </Button>
+          </div>
           {cloneRun.isError && <p className="text-xs text-danger">Failed to clone this run.</p>}
         </div>
       </div>

--- a/frontend/src/components/training/ExportConfigLink.tsx
+++ b/frontend/src/components/training/ExportConfigLink.tsx
@@ -1,0 +1,15 @@
+import { runConfigYamlUrl } from '../../api/queries/training'
+
+// Styled to match <Button variant="secondary" size="sm"> — a native anchor so
+// the browser handles the attachment download without any JS fetch/blob work.
+export function ExportConfigLink({ runId }: { runId: string }) {
+  return (
+    <a
+      href={runConfigYamlUrl(runId)}
+      download
+      className="inline-flex h-8 items-center justify-center gap-2 rounded-lg border border-border bg-surface-raised px-3 text-sm font-medium text-text transition-colors hover:bg-surface"
+    >
+      Export YAML
+    </a>
+  )
+}

--- a/frontend/src/components/training/RunMonitor.test.tsx
+++ b/frontend/src/components/training/RunMonitor.test.tsx
@@ -230,6 +230,24 @@ describe('RunMonitor - live run', () => {
 })
 
 describe('RunMonitor - past run', () => {
+  it('links an Export YAML download for the viewed run', async () => {
+    server.use(
+      http.get('/api/v1/train/jobs/run_2', () =>
+        HttpResponse.json(makeRunSummary({ run_id: 'run_2', status: 'completed' })),
+      ),
+      http.get('/api/v1/train/jobs/run_2/metrics', () => HttpResponse.json({ metrics: [] })),
+      http.get('/api/v1/train/jobs/run_2/logs', () => HttpResponse.json({ lines: [] })),
+    )
+
+    renderWithProviders(
+      <RunMonitor runId="run_2" WebSocketImpl={MockWebSocket as unknown as typeof WebSocket} />,
+    )
+
+    const link = await screen.findByRole('link', { name: 'Export YAML' })
+    expect(link).toHaveAttribute('href', '/api/v1/train/jobs/run_2/config.yaml')
+    expect(link).toHaveAttribute('download')
+  })
+
   it('renders static charts from REST metrics without opening a WebSocket', async () => {
     server.use(
       http.get('/api/v1/train/jobs/run_2', () =>

--- a/frontend/src/components/training/RunMonitor.tsx
+++ b/frontend/src/components/training/RunMonitor.tsx
@@ -17,6 +17,7 @@ import { Spinner } from '../common/Spinner'
 import { LossChart } from '../charts/LossChart'
 import { LRChart } from '../charts/LRChart'
 import { MemoryChart } from '../charts/MemoryChart'
+import { ExportConfigLink } from './ExportConfigLink'
 import { StatTile } from './StatTile'
 import { LiveLogViewer } from './LiveLogViewer'
 
@@ -166,11 +167,14 @@ export function RunMonitor({ runId, WebSocketImpl }: RunMonitorProps) {
               {run.config.model_id} · {run.config.dataset_id} · {elapsed}
             </p>
           </div>
-          {canCancel && (
-            <Button variant="danger" size="sm" onClick={() => setConfirmCancel(true)}>
-              Cancel run
-            </Button>
-          )}
+          <div className="flex items-center gap-2">
+            <ExportConfigLink runId={run.run_id} />
+            {canCancel && (
+              <Button variant="danger" size="sm" onClick={() => setConfirmCancel(true)}>
+                Cancel run
+              </Button>
+            )}
+          </div>
         </div>
       </Card>
 

--- a/frontend/src/components/training/TrainConfigForm.test.tsx
+++ b/frontend/src/components/training/TrainConfigForm.test.tsx
@@ -10,6 +10,8 @@ import { DEFAULT_TRAINING_CONFIG } from './defaults'
 import {
   ftpoDataset,
   grpoDataset,
+  importConfigHandler,
+  importConfigInvalidHandler,
   makeRunSummary,
   splitDataset,
   trainingHandlers,
@@ -594,5 +596,55 @@ describe('TrainConfigForm', () => {
     await user.click(screen.getByRole('button', { name: 'Start training' }))
 
     expect(await screen.findByText('A training job is already queued or running.')).toBeInTheDocument()
+  })
+
+  it('Load YAML: choosing a file prefills the form from the imported config', async () => {
+    const user = userEvent.setup()
+    const imported = {
+      ...DEFAULT_TRAINING_CONFIG,
+      name: 'imported-run',
+      model_id: trainModel.model_id,
+      dataset_id: grpoDataset.dataset_id,
+      train_mode: 'grpo' as const,
+      iters: 4321,
+      group_size: 8,
+      temperature: 0.7,
+      max_completion_length: 256,
+      reward_functions: ['r1_accuracy_reward_func', 'r1_count_xml'],
+    }
+    server.use(importConfigHandler(imported))
+    renderForm()
+    await waitForPickersLoaded()
+
+    const file = new File(['config_schema: 1\nconfig: {}\n'], 'run.yaml', {
+      type: 'application/x-yaml',
+    })
+    await user.upload(screen.getByLabelText('Training config YAML file'), file)
+
+    await waitFor(() => expect(screen.getByDisplayValue('imported-run')).toBeInTheDocument())
+    expect(screen.getByDisplayValue('4321')).toBeInTheDocument()
+    // The imported grpo mode drives the conditional section + checkbox state.
+    expect(screen.getByRole('radio', { name: 'GRPO' })).toBeChecked()
+    expect(screen.getByLabelText('Group size')).toHaveValue(8)
+    expect(screen.getByRole('checkbox', { name: /r1_accuracy_reward_func/ })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: /r1_count_xml/ })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: /r1_int_reward_func/ })).not.toBeChecked()
+    expect(await screen.findByText('Config loaded from YAML.')).toBeInTheDocument()
+  })
+
+  it('Load YAML: surfaces the backend 422 message naming the offending keys', async () => {
+    const user = userEvent.setup()
+    server.use(importConfigInvalidHandler("unknown key(s) under config: 'learning_rte'"))
+    renderForm()
+    await waitForPickersLoaded()
+
+    const file = new File(['config:\n  learning_rte: 1\n'], 'bad.yaml')
+    await user.upload(screen.getByLabelText('Training config YAML file'), file)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      "unknown key(s) under config: 'learning_rte'",
+    )
+    // The form keeps its previous values.
+    expect(screen.getByLabelText('Run name')).toHaveValue('')
   })
 })

--- a/frontend/src/components/training/TrainConfigForm.tsx
+++ b/frontend/src/components/training/TrainConfigForm.tsx
@@ -1,8 +1,8 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useModels } from '../../api/queries/models'
 import { useDatasets } from '../../api/queries/datasets'
-import { useCreateRun } from '../../api/queries/training'
+import { useCreateRun, useImportTrainingConfig } from '../../api/queries/training'
 import { ApiError } from '../../api/client'
 import type { LoraParams, SftLossType, TrainingConfig, TrainMode, TrainType } from '../../api/types'
 import { Card } from '../common/Card'
@@ -41,6 +41,10 @@ export function TrainConfigForm({ onCreated, initialConfig }: TrainConfigFormPro
   const [config, setConfig] = useState<TrainingConfig>(initialConfig ?? DEFAULT_TRAINING_CONFIG)
   const [touched, setTouched] = useState(false)
 
+  const importConfig = useImportTrainingConfig()
+  const [importError, setImportError] = useState<string | null>(null)
+  const importInputRef = useRef<HTMLInputElement>(null)
+
   const splitDatasets = useMemo(
     () => (datasetsQuery.data?.datasets ?? []).filter((d) => d.splits !== null),
     [datasetsQuery.data],
@@ -76,6 +80,27 @@ export function TrainConfigForm({ onCreated, initialConfig }: TrainConfigFormPro
     })
   }
 
+  function handleImportFile(files: FileList | null) {
+    const file = files?.[0]
+    // Reset so picking the same file again re-fires the change event.
+    if (importInputRef.current) importInputRef.current.value = ''
+    if (!file) return
+    setImportError(null)
+    importConfig.mutate(file, {
+      onSuccess: (loaded) => {
+        setConfig(loaded)
+        setTouched(false)
+        toast('Config loaded from YAML.', { variant: 'success' })
+      },
+      onError: (error) => {
+        // 422s name the offending keys — surface the backend message verbatim.
+        setImportError(
+          error instanceof ApiError ? error.message : 'Failed to import the YAML config.',
+        )
+      },
+    })
+  }
+
   function handleSubmit(event: React.FormEvent) {
     event.preventDefault()
     setTouched(true)
@@ -100,6 +125,29 @@ export function TrainConfigForm({ onCreated, initialConfig }: TrainConfigFormPro
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-6">
+      <div className="flex flex-col items-end gap-1">
+        <Button
+          variant="secondary"
+          size="sm"
+          loading={importConfig.isPending}
+          onClick={() => importInputRef.current?.click()}
+        >
+          Load YAML
+        </Button>
+        <input
+          ref={importInputRef}
+          type="file"
+          accept=".yaml,.yml"
+          className="hidden"
+          aria-label="Training config YAML file"
+          onChange={(e) => handleImportFile(e.target.files)}
+        />
+        {importError && (
+          <p role="alert" className="text-xs text-danger">
+            {importError}
+          </p>
+        )}
+      </div>
       <Card title="Run">
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           <Field label="Run name" htmlFor="run-name" error={touched ? errors.name : undefined}>

--- a/frontend/src/pages/HistoryPage.test.tsx
+++ b/frontend/src/pages/HistoryPage.test.tsx
@@ -148,6 +148,21 @@ describe('HistoryPage', () => {
     expect(await within(panel).findByText('Train loss')).toBeInTheDocument()
   })
 
+  it('offers an Export YAML download link for the selected run', async () => {
+    const user = userEvent.setup()
+    const run = makeRunSummary({ run_id: 'run_1', name: 'first-run' })
+    server.use(listRunHistoryHandler([run], 1))
+
+    renderWithProviders(<HistoryPage />)
+    const table = await screen.findByTestId('history-table')
+    await user.click(within(table).getByText('first-run'))
+
+    const panel = await screen.findByTestId('run-detail-panel')
+    const link = within(panel).getByRole('link', { name: 'Export YAML' })
+    expect(link).toHaveAttribute('href', '/api/v1/train/jobs/run_1/config.yaml')
+    expect(link).toHaveAttribute('download')
+  })
+
   it('clones a run: navigates to /train with the config prefilled', async () => {
     const user = userEvent.setup()
     const run = makeRunSummary({ run_id: 'run_1', name: 'first-run' })

--- a/frontend/src/test/handlers/training.ts
+++ b/frontend/src/test/handlers/training.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from 'msw'
-import type { DatasetInfo, ModelInfo, RunSummary } from '../../api/types'
+import type { DatasetInfo, ModelInfo, RunSummary, TrainingConfig } from '../../api/types'
 
 // Additional MSW handlers for Train-page tests (TrainConfigForm, RunMonitor,
 // TrainPage). These are additive overrides applied per-test via
@@ -102,6 +102,23 @@ export function makeRunSummary(overrides: Partial<RunSummary> = {}): RunSummary 
     error: null,
     ...overrides,
   }
+}
+
+/** POST /train/configs/import happy path → the given validated TrainingConfig. */
+export function importConfigHandler(config: TrainingConfig) {
+  return http.post('/api/v1/train/configs/import', () => HttpResponse.json(config))
+}
+
+/** POST /train/configs/import strict-validation failure (422 names the offending keys). */
+export function importConfigInvalidHandler(
+  message = "unknown key(s) under config: 'learning_rte'",
+) {
+  return http.post('/api/v1/train/configs/import', () =>
+    HttpResponse.json(
+      { error: { code: 'validation_error', message, detail: {} } },
+      { status: 422 },
+    ),
+  )
 }
 
 export const trainingHandlers = [


### PR DESCRIPTION
New feature: a fine-tuning experiment's full configuration — every hyperparameter plus model/dataset identifiers — can be exported as a YAML file and loaded back into the train form. Three commits, contract-first.

## Contract (`a198c4e`)

- **`GET /train/jobs/{run_id}/config.yaml`** — downloads the run's configuration as an attachment. Document shape: `config_schema: 1`, an informational `metadata:` block (export timestamp, app + mlx-lm-lora versions, run id/status, final losses), and `config:` with exactly the `TrainingConfig` fields.
- **`POST /train/configs/import`** — multipart YAML upload → validated `TrainingConfig` JSON, ready to prefill the form. **Strict**: unparsable YAML, `config_schema != 1` (absent counts as wrong), missing `config` mapping, or any unknown key under `config` → 422 naming the problem, on top of all standard `TrainingConfig` rules (mode-conditional fields, reward-function names…).

## Backend (`3d4d479`)

New `services/config_yaml.py` (single canonical serializer/parser; yaml+pydantic only, mlx-free): `yaml.safe_dump(sort_keys=False)` keeps field order matching the model; the parse side implements the strict 422 cascade with messages that name offending keys. Routes wired in `api/training.py` (404 mirrors the run-detail endpoint; 256 KiB upload cap). PyYAML added with repo-policy bounds — lock diff touches only pyyaml (it was already in the tree as a transitive dep).

## Frontend (`79adf09`)

- **Export YAML** actions on the History run-detail panel (next to Clone) and the RunMonitor header — plain download anchors to the attachment endpoint (shared `ExportConfigLink`).
- **Load YAML** button on the train form: posts the file, seeds the form with the validated config through the same state the clone flow uses (grpo example: mode radio, group_size, and the right reward-function checkboxes all light up). The backend's 422 message is shown verbatim in an alert; success resets touched-state with a toast.

## Tests (+34)

- Backend 29: document shape/field order, sft/grpo/ftpo round trips (unit + API level), headers, 404, and every 422 branch (garbage, YAML list, missing config, unknown key named, wrong schema, dpo-without-beta, oversize).
- Frontend 5: import happy path asserting distinctive prefills, 422 alert with untouched form, export link href/download attributes on both surfaces.

## Verification

- `make test`: backend **445 passed**, frontend **256 passed** (baseline 416/252)
- `make lint` clean; `make build` succeeds

Next up (PR 2, after this merges): the README GRPO walkthrough with real UI screenshots, including a ready-to-load YAML config that exercises this feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UEysgYYG512HSnoKf5cgm

---
_Generated by [Claude Code](https://claude.ai/code/session_014UEysgYYG512HSnoKf5cgm)_