### PR TITLE
Changelog: record YAML config export/import and the GRPO walkthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ The version's source of truth is `backend/pyproject.toml` (reported by
 
 ## [Unreleased]
 
+### Added
+
+- Training configs export/load as YAML: download any run's full configuration
+  (`GET /train/jobs/{run_id}/config.yaml` — hyperparameters, model/dataset ids,
+  informational metadata) from the History panel or the run monitor, and load
+  a document back into the train form via the strict-validating
+  `POST /train/configs/import` (#47)
+- README: end-to-end GRPO fine-tuning walkthrough — dataset format, all five
+  reward functions explained, a ready-to-load YAML config, and a UI
+  screenshot (#48)
+
 ## [0.1.0] - 2026-07-16
 
 First release: local LoRA/DoRA/full fine-tuning studio for Apple Silicon —


### PR DESCRIPTION
Adds the two just-shipped items to `[Unreleased]` in Keep-a-Changelog style:

- **Added**: YAML training-config export (`GET /train/jobs/{run_id}/config.yaml` from History / run monitor) and strict-validating load back into the train form (#47)
- **Added**: README end-to-end GRPO fine-tuning walkthrough with reward-function explanations, a ready-to-load YAML config, and a UI screenshot (#48)

Docs-only, single file. These will roll into the next version section (e.g. `[0.2.0]`) at release time per the CONTRIBUTING release steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UEysgYYG512HSnoKf5cgm

---
_Generated by [Claude Code](https://claude.ai/code/session_014UEysgYYG512HSnoKf5cgm)_