### PR TITLE
Custom GRPO reward functions: upload .py files, discover and pick their rewards

### DIFF
--- a/backend/app/api/reward_files.py
+++ b/backend/app/api/reward_files.py
@@ -1,0 +1,56 @@
+"""Custom GRPO reward file endpoints (docs/api.md: /train/reward-files).
+
+Thin HTTP layer over `app.services.reward_files_service` — upload with static
+AST function discovery, listing, and deletion with an active-run 409 guard.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+from fastapi import APIRouter, Depends, File, UploadFile
+from pydantic import BaseModel
+
+from app.core.errors import ValidationAppError
+from app.db.repositories import RunsRepo
+from app.deps import get_current_user, get_db
+from app.schemas.training import RewardFileInfo
+from app.services.reward_files_service import (
+    MAX_REWARD_FILE_BYTES,
+    RewardFilesService,
+    get_reward_files_service,
+)
+
+router = APIRouter(dependencies=[Depends(get_current_user)])
+
+
+class RewardFilesListResponse(BaseModel):
+    files: list[RewardFileInfo]
+
+
+@router.post("/train/reward-files", response_model=RewardFileInfo, status_code=201)
+async def upload_reward_file(
+    file: UploadFile = File(...),
+    service: RewardFilesService = Depends(get_reward_files_service),
+) -> RewardFileInfo:
+    # Read one byte past the cap so an oversize upload is detected without
+    # buffering an arbitrarily large body (same as POST /train/configs/import).
+    raw = await file.read(MAX_REWARD_FILE_BYTES + 1)
+    if not file.filename:
+        raise ValidationAppError("uploaded reward file has no filename")
+    return service.save_reward_file(file.filename, raw)
+
+
+@router.get("/train/reward-files", response_model=RewardFilesListResponse)
+async def list_reward_files(
+    service: RewardFilesService = Depends(get_reward_files_service),
+) -> RewardFilesListResponse:
+    return RewardFilesListResponse(files=service.list_reward_files())
+
+
+@router.delete("/train/reward-files/{name}", status_code=204)
+async def delete_reward_file(
+    name: str,
+    db: aiosqlite.Connection = Depends(get_db),
+    service: RewardFilesService = Depends(get_reward_files_service),
+) -> None:
+    await service.delete_reward_file(RunsRepo(db), name)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -40,6 +40,10 @@ class Settings(BaseSettings):
         return self.data_dir / "cache"
 
     @property
+    def rewards_dir(self) -> Path:
+        return self.data_dir / "rewards"
+
+    @property
     def db_path(self) -> Path:
         return self.data_dir / "app.db"
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,7 +19,18 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.responses import Response
 from starlette.types import Scope
 
-from app.api import arena, datasets, export, history, inference, models, recipes, system, training
+from app.api import (
+    arena,
+    datasets,
+    export,
+    history,
+    inference,
+    models,
+    recipes,
+    reward_files,
+    system,
+    training,
+)
 from app.config import get_settings
 from app.core.errors import register_exception_handlers
 from app.db.database import init_db
@@ -86,6 +97,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         settings.runs_dir,
         settings.exports_dir,
         settings.cache_dir,
+        settings.rewards_dir,
     ):
         directory.mkdir(parents=True, exist_ok=True)
 
@@ -118,6 +130,7 @@ def create_app() -> FastAPI:
         models,
         datasets,
         training,
+        reward_files,
         inference,
         arena,
         export,

--- a/backend/app/schemas/training.py
+++ b/backend/app/schemas/training.py
@@ -1,6 +1,7 @@
+import re
 from enum import Enum
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 class TrainMode(str, Enum):
@@ -37,6 +38,21 @@ GRPO_REWARD_FUNCTION_NAMES = frozenset(
         "r1_count_xml",
     }
 )
+
+
+# Contract (docs/api.md): reward file names use the same safe-name charset as
+# export names — letters, digits, `.`, `_`, `-`; no path separators or a
+# leading `.`/`-`. Shared by the schema validator below and
+# `app.services.reward_files_service`.
+REWARD_FILE_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+
+class RewardFileInfo(BaseModel):
+    """One uploaded custom GRPO reward file (docs/api.md /train/reward-files)."""
+
+    name: str
+    functions: list[str]
+    uploaded_at: str
 
 
 class JobStatus(str, Enum):
@@ -80,11 +96,32 @@ class TrainingConfig(BaseModel):
     temperature: float | None = None
     max_completion_length: int | None = None
     reward_functions: list[str] | None = None
+    reward_functions_file: str | None = None
     sft_loss_type: SftLossType | None = None
     lambda_mse_target: float | None = None
     tau_mse_target: float | None = None
     lambda_mse: float | None = None
     clip_epsilon_logits: float | None = None
+
+    @field_validator("reward_functions_file")
+    @classmethod
+    def normalize_reward_functions_file(cls, value: str | None) -> str | None:
+        """Normalize the reference to the stored file's stem.
+
+        docs/api.md: the `.py` extension is optional in the reference, so one
+        trailing `.py` is stripped before validation and the config always
+        stores/compares on the stem (matching what upload derives from the
+        filename and what delete's conflict check compares against).
+        """
+        if value is None:
+            return None
+        name = value[:-3] if value.endswith(".py") else value
+        if not REWARD_FILE_NAME_PATTERN.match(name):
+            raise ValueError(
+                "reward_functions_file must be a plain reward file name "
+                "(letters, digits, '.', '_', '-'; not starting with '.' or '-')"
+            )
+        return name
 
     @model_validator(mode="after")
     def check_mode_conditional_fields(self) -> "TrainingConfig":
@@ -94,7 +131,13 @@ class TrainingConfig(BaseModel):
             raise ValueError("group_size is required for grpo train_mode")
         if self.sft_loss_type is not None and self.train_mode != TrainMode.SFT:
             raise ValueError("sft_loss_type is only accepted for sft train_mode")
-        if self.reward_functions:
+        if self.reward_functions_file is not None and self.train_mode != TrainMode.GRPO:
+            raise ValueError("reward_functions_file is only accepted for grpo train_mode")
+        # When a custom reward file is set the registry check is skipped: the
+        # file may register new names, so they cannot be validated statically.
+        # An unresolvable name then aborts the run at start (reported as a
+        # failed run) — docs/api.md documents this trade-off.
+        if self.reward_functions and self.reward_functions_file is None:
             unknown = sorted(set(self.reward_functions) - GRPO_REWARD_FUNCTION_NAMES)
             if unknown:
                 raise ValueError(

--- a/backend/app/services/reward_files_service.py
+++ b/backend/app/services/reward_files_service.py
@@ -1,0 +1,200 @@
+"""Custom GRPO reward file management (docs/api.md: /train/reward-files).
+
+Uploaded files live under `MLXLF_DATA_DIR/rewards/<name>.py` and are referenced
+by name from `TrainingConfig.reward_functions_file`. Function discovery is
+STATIC — a stdlib `ast` scan for `@register_reward_function`-decorated
+functions; the API never executes the file. Only the training worker executes
+it (via mlx-lm-lora's `load_reward_functions_from_file` at run start).
+
+No mlx imports here — this module must stay importable on the mlx-less
+Linux CI runner.
+"""
+
+from __future__ import annotations
+
+import ast
+from datetime import datetime, timezone
+from functools import lru_cache
+from pathlib import Path
+
+from app.config import Settings, get_settings
+from app.core.errors import ConflictError, NotFoundError, ValidationAppError
+from app.db.repositories import RunsRepo
+from app.schemas.training import (
+    REWARD_FILE_NAME_PATTERN,
+    RewardFileInfo,
+    TrainingConfig,
+)
+
+MAX_REWARD_FILE_BYTES = 256 * 1024
+
+REWARD_DECORATOR_NAME = "register_reward_function"
+
+
+def _mtime_iso(path: Path) -> str:
+    """File mtime in the same UTC ISO-8601 shape the rest of the app emits."""
+    dt = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
+def _decorator_target_name(node: ast.expr) -> str | None:
+    """Extract the trailing identifier a decorator expression refers to.
+
+    Handles `@register_reward_function`, `@register_reward_function(...)`,
+    and attribute forms like `@grpo_reward_functions.register_reward_function()`
+    (any dotted prefix — only the final attribute matters).
+    """
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _registered_name(decorator: ast.expr, func_name: str) -> str | None:
+    """Return the registry name a decorator would register, or None if the
+    decorator is not `register_reward_function` at all.
+
+    Mirrors mlx-lm-lora's `register_reward_function(name=None)`: an explicit
+    string `name=` keyword (or a single positional string literal) wins,
+    otherwise the function's own name is used.
+    """
+    target = decorator.func if isinstance(decorator, ast.Call) else decorator
+    if _decorator_target_name(target) != REWARD_DECORATOR_NAME:
+        return None
+    if isinstance(decorator, ast.Call):
+        for kw in decorator.keywords:
+            if kw.arg == "name" and isinstance(kw.value, ast.Constant) and isinstance(
+                kw.value.value, str
+            ):
+                return kw.value.value
+        if (
+            decorator.args
+            and isinstance(decorator.args[0], ast.Constant)
+            and isinstance(decorator.args[0].value, str)
+        ):
+            return decorator.args[0].value
+    return func_name
+
+
+def discover_reward_functions(tree: ast.Module) -> list[str]:
+    """Names of all `@register_reward_function`-decorated functions, in
+    definition order. Walks the whole tree, so nested/class-level definitions
+    count too — discovery is informational (listing), not an execution model.
+    """
+    names: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for decorator in node.decorator_list:
+            registered = _registered_name(decorator, node.name)
+            if registered is not None:
+                names.append(registered)
+                break
+    return names
+
+
+def resolve_reward_file_path(name: str, settings: Settings | None = None) -> Path | None:
+    """Absolute path of an uploaded reward file, or None if it doesn't exist.
+
+    `name` is the stored stem (TrainingConfig normalizes references to it).
+    """
+    settings = settings or get_settings()
+    path = settings.rewards_dir / f"{name}.py"
+    return path if path.is_file() else None
+
+
+class RewardFilesService:
+    """Upload / list / delete for custom GRPO reward files."""
+
+    @property
+    def _rewards_dir(self) -> Path:
+        # Resolved per call (not cached) so tests that reset MLXLF_DATA_DIR
+        # via `get_settings.cache_clear()` always see the fresh directory.
+        return get_settings().rewards_dir
+
+    def _parse(self, content: bytes, *, origin: str) -> ast.Module:
+        try:
+            text = content.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValidationAppError(f"{origin} is not parseable Python: {exc}") from exc
+        try:
+            return ast.parse(text)
+        except SyntaxError as exc:
+            raise ValidationAppError(f"{origin} is not parseable Python: {exc}") from exc
+
+    def save_reward_file(self, filename: str, content: bytes) -> RewardFileInfo:
+        if not filename.endswith(".py"):
+            raise ValidationAppError("reward file must have a .py extension")
+        name = filename[: -len(".py")]
+        if not REWARD_FILE_NAME_PATTERN.match(name):
+            raise ValidationAppError(
+                f"invalid reward file name '{filename}': the name before .py must use "
+                "letters, digits, '.', '_' or '-' only and not start with '.' or '-'"
+            )
+        if len(content) > MAX_REWARD_FILE_BYTES:
+            raise ValidationAppError(
+                f"reward file is too large (max {MAX_REWARD_FILE_BYTES // 1024} KiB)"
+            )
+
+        tree = self._parse(content, origin="uploaded file")
+        functions = discover_reward_functions(tree)
+        if not functions:
+            raise ValidationAppError(
+                "no @register_reward_function-decorated function found in the uploaded file"
+            )
+
+        self._rewards_dir.mkdir(parents=True, exist_ok=True)
+        path = self._rewards_dir / f"{name}.py"
+        path.write_bytes(content)  # re-uploading the same name overwrites
+        return RewardFileInfo(name=name, functions=functions, uploaded_at=_mtime_iso(path))
+
+    def list_reward_files(self) -> list[RewardFileInfo]:
+        rewards_dir = self._rewards_dir
+        if not rewards_dir.is_dir():
+            return []
+        files: list[RewardFileInfo] = []
+        for path in sorted(rewards_dir.glob("*.py")):
+            if not REWARD_FILE_NAME_PATTERN.match(path.stem):
+                continue  # stray file that could never have been uploaded
+            # Tolerate unreadable/corrupted-on-disk files by skipping them —
+            # one bad file must not 500 the whole listing.
+            try:
+                tree = ast.parse(path.read_bytes().decode("utf-8"))
+            except (OSError, UnicodeDecodeError, SyntaxError):
+                continue
+            files.append(
+                RewardFileInfo(
+                    name=path.stem,
+                    functions=discover_reward_functions(tree),
+                    uploaded_at=_mtime_iso(path),
+                )
+            )
+        return files
+
+    async def delete_reward_file(self, runs_repo: RunsRepo, name: str) -> None:
+        # Accept an optional trailing `.py` in the path segment, mirroring how
+        # TrainingConfig normalizes references.
+        if name.endswith(".py"):
+            name = name[: -len(".py")]
+        path = self._rewards_dir / f"{name}.py"
+        if not REWARD_FILE_NAME_PATTERN.match(name) or not path.is_file():
+            raise NotFoundError(f"reward file '{name}' not found")
+
+        # Same guard shape as dataset deletion: the DB is the source of truth
+        # for active (queued/running) runs, so the check also holds across
+        # manager restarts.
+        for row in await runs_repo.list_active():
+            config = TrainingConfig.model_validate_json(row["config_json"])
+            if config.reward_functions_file == name:
+                raise ConflictError(
+                    f"reward file '{name}' is referenced by the active training run "
+                    f"'{row['run_id']}'"
+                )
+
+        path.unlink()
+
+
+@lru_cache
+def get_reward_files_service() -> RewardFilesService:
+    return RewardFilesService()

--- a/backend/app/training/manager.py
+++ b/backend/app/training/manager.py
@@ -187,6 +187,17 @@ class JobManager:
                         "call POST /datasets/{id}/split first"
                     )
 
+                if config.reward_functions_file is not None:
+                    from app.services.reward_files_service import resolve_reward_file_path
+
+                    if resolve_reward_file_path(
+                        config.reward_functions_file, settings=self._settings
+                    ) is None:
+                        raise ValidationAppError(
+                            f"reward file '{config.reward_functions_file}' not found — "
+                            "upload it via /train/reward-files"
+                        )
+
                 allowed_formats = DATASET_FORMAT_COMPAT[config.train_mode.value]
                 if dataset_row["format"] not in allowed_formats:
                     raise ValidationAppError(

--- a/backend/app/training/worker.py
+++ b/backend/app/training/worker.py
@@ -174,6 +174,13 @@ def _build_worker_args(run_dir: Path, config, train_mod=None):
             default_args[key] = value
     if config.reward_functions:
         default_args["reward_functions"] = ",".join(config.reward_functions)
+    if config.reward_functions_file:
+        # Absolute path under MLXLF_DATA_DIR/rewards; the library importlib-
+        # execs the file (registering its @register_reward_function functions)
+        # BEFORE resolving reward_functions names, so custom names become valid.
+        default_args["reward_functions_file"] = str(
+            settings.rewards_dir / f"{config.reward_functions_file}.py"
+        )
 
     return types.SimpleNamespace(**default_args)
 

--- a/backend/tests/fixtures/training_helpers.py
+++ b/backend/tests/fixtures/training_helpers.py
@@ -119,5 +119,6 @@ def ensure_data_dirs(settings: Settings) -> None:
         settings.runs_dir,
         settings.exports_dir,
         settings.cache_dir,
+        settings.rewards_dir,
     ):
         directory.mkdir(parents=True, exist_ok=True)

--- a/backend/tests/integration/test_reward_files_api.py
+++ b/backend/tests/integration/test_reward_files_api.py
@@ -1,0 +1,112 @@
+"""Integration tests for /train/reward-files (docs/api.md: custom GRPO reward files)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.config import get_settings
+
+VALID_SOURCE = (
+    b"from mlx_lm_lora.trainer.grpo_reward_functions import register_reward_function\n"
+    b"\n"
+    b"@register_reward_function()\n"
+    b"def my_reward(prompts, completions, answers, types=None):\n"
+    b"    return [1.0 for _ in completions]\n"
+    b"\n"
+    b"@register_reward_function(name='named_reward')\n"
+    b"def helper(prompts, completions, answers, types=None):\n"
+    b"    return [0.0 for _ in completions]\n"
+)
+
+
+def _upload_files(filename: str = "my_rewards.py", content: bytes = VALID_SOURCE) -> dict:
+    return {"file": (filename, content, "text/x-python")}
+
+
+@pytest.mark.asyncio
+async def test_upload_list_delete_happy_path(client):
+    upload = await client.post("/api/v1/train/reward-files", files=_upload_files())
+    assert upload.status_code == 201
+    body = upload.json()
+    assert body["name"] == "my_rewards"
+    assert body["functions"] == ["my_reward", "named_reward"]
+    assert isinstance(body["uploaded_at"], str) and body["uploaded_at"]
+
+    listing = await client.get("/api/v1/train/reward-files")
+    assert listing.status_code == 200
+    files = listing.json()["files"]
+    assert len(files) == 1
+    assert files[0]["name"] == "my_rewards"
+    assert files[0]["functions"] == ["my_reward", "named_reward"]
+    assert set(files[0]) == {"name", "functions", "uploaded_at"}
+
+    deleted = await client.delete("/api/v1/train/reward-files/my_rewards")
+    assert deleted.status_code == 204
+
+    empty = await client.get("/api/v1/train/reward-files")
+    assert empty.json()["files"] == []
+
+
+@pytest.mark.asyncio
+async def test_upload_writes_under_rewards_dir(client):
+    resp = await client.post("/api/v1/train/reward-files", files=_upload_files())
+    assert resp.status_code == 201
+    assert (get_settings().rewards_dir / "my_rewards.py").is_file()
+
+
+@pytest.mark.asyncio
+async def test_upload_syntax_error_returns_422(client):
+    resp = await client.post(
+        "/api/v1/train/reward-files",
+        files=_upload_files(content=b"def broken(:\n    pass\n"),
+    )
+    assert resp.status_code == 422
+    error = resp.json()["error"]
+    assert error["code"] == "validation_error"
+    assert "not parseable Python" in error["message"]
+
+
+@pytest.mark.asyncio
+async def test_upload_without_decorated_function_returns_422(client):
+    resp = await client.post(
+        "/api/v1/train/reward-files",
+        files=_upload_files(content=b"def plain():\n    return []\n"),
+    )
+    assert resp.status_code == 422
+    assert resp.json()["error"]["code"] == "validation_error"
+
+
+@pytest.mark.asyncio
+async def test_upload_bad_name_returns_422(client):
+    resp = await client.post(
+        "/api/v1/train/reward-files", files=_upload_files(filename=".hidden.py")
+    )
+    assert resp.status_code == 422
+
+    not_py = await client.post(
+        "/api/v1/train/reward-files", files=_upload_files(filename="rewards.txt")
+    )
+    assert not_py.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_delete_missing_returns_404(client):
+    resp = await client.delete("/api/v1/train/reward-files/nope")
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "not_found"
+
+
+@pytest.mark.asyncio
+async def test_config_with_reward_file_on_sft_returns_422(client):
+    resp = await client.post(
+        "/api/v1/train/jobs",
+        json={
+            "name": "bad-run",
+            "model_id": "mlx-community/Tiny-1",
+            "dataset_id": "ds_1",
+            "train_mode": "sft",
+            "reward_functions_file": "my_rewards",
+        },
+    )
+    assert resp.status_code == 422
+    assert resp.json()["error"]["code"] == "validation_error"

--- a/backend/tests/unit/test_config_yaml.py
+++ b/backend/tests/unit/test_config_yaml.py
@@ -112,8 +112,16 @@ def test_render_null_losses_while_running():
             lambda_mse=0.1,
             clip_epsilon_logits=2.0,
         ),
+        _config(
+            name="grpo-custom-rewards",
+            train_mode="grpo",
+            group_size=4,
+            reward_functions_file="my_rewards",
+            # Arbitrary (non-registry) name: allowed because a custom file is set.
+            reward_functions=["my_custom_reward"],
+        ),
     ],
-    ids=["sft", "grpo", "ftpo"],
+    ids=["sft", "grpo", "ftpo", "grpo-reward-file"],
 )
 def test_round_trip_export_import_identical(config):
     text = render_config_yaml(_run(config))

--- a/backend/tests/unit/test_reward_files_service.py
+++ b/backend/tests/unit/test_reward_files_service.py
@@ -1,0 +1,245 @@
+"""Unit tests for app/services/reward_files_service.py.
+
+Pure stdlib-ast service — no mlx anywhere. The delete conflict tests seed a
+queued run row directly in SQLite (like the manager tests do) because the
+service reads active runs from the DB, not from in-memory manager state.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from app.config import get_settings
+from app.core.errors import ConflictError, NotFoundError, ValidationAppError
+from app.db.database import init_db
+from app.db.repositories import RunsRepo
+from app.schemas.training import TrainingConfig
+from app.services.reward_files_service import (
+    MAX_REWARD_FILE_BYTES,
+    RewardFilesService,
+    resolve_reward_file_path,
+)
+
+VALID_SOURCE = b"""
+from mlx_lm_lora.trainer import grpo_reward_functions
+from mlx_lm_lora.trainer.grpo_reward_functions import register_reward_function
+
+
+@register_reward_function()
+def called_decorator_reward(prompts, completions, answers, types=None):
+    return [1.0 for _ in completions]
+
+
+@register_reward_function
+def plain_decorator_reward(prompts, completions, answers, types=None):
+    return [0.0 for _ in completions]
+
+
+@grpo_reward_functions.register_reward_function(name="custom_named_reward")
+def some_function_name(prompts, completions, answers, types=None):
+    return [0.5 for _ in completions]
+
+
+def not_a_reward_function():
+    return None
+"""
+
+
+@pytest.fixture
+def service(data_dir):
+    return RewardFilesService()
+
+
+@pytest.fixture
+def settings(data_dir):
+    return get_settings()
+
+
+# ------------------------------------------------------------------- upload
+
+
+def test_save_discovers_all_decorator_forms(service):
+    info = service.save_reward_file("my_rewards.py", VALID_SOURCE)
+    assert info.name == "my_rewards"
+    assert info.functions == [
+        "called_decorator_reward",
+        "plain_decorator_reward",
+        "custom_named_reward",
+    ]
+    assert info.uploaded_at.endswith("Z")
+
+
+def test_save_writes_file_to_rewards_dir(service, settings):
+    service.save_reward_file("my_rewards.py", VALID_SOURCE)
+    path = settings.rewards_dir / "my_rewards.py"
+    assert path.is_file()
+    assert path.read_bytes() == VALID_SOURCE
+
+
+def test_save_syntax_error_raises_422(service):
+    with pytest.raises(ValidationAppError, match="not parseable Python") as exc_info:
+        service.save_reward_file("broken.py", b"def broken(:\n    pass\n")
+    assert exc_info.value.status_code == 422
+
+
+def test_save_non_utf8_raises_422(service):
+    with pytest.raises(ValidationAppError, match="not parseable Python"):
+        service.save_reward_file("binary.py", b"\xff\xfe\x00garbage")
+
+
+def test_save_without_decorated_function_raises_422(service):
+    source = b"def plain(prompts, completions, answers, types=None):\n    return []\n"
+    with pytest.raises(ValidationAppError, match="no @register_reward_function"):
+        service.save_reward_file("plain.py", source)
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "rewards.txt",  # not .py
+        "rewards",  # no extension at all
+        ".hidden.py",  # leading dot
+        "-dash.py",  # leading dash
+        "sub/dir.py",  # path separator
+        "..%2F..%2Fetc.py",  # separator-ish charset violation
+        ("x" * 129) + ".py",  # stem too long
+    ],
+)
+def test_save_bad_name_raises_422(service, filename):
+    with pytest.raises(ValidationAppError):
+        service.save_reward_file(filename, VALID_SOURCE)
+
+
+def test_save_oversize_raises_422(service):
+    padding = b"# " + b"x" * MAX_REWARD_FILE_BYTES + b"\n"
+    with pytest.raises(ValidationAppError, match="too large"):
+        service.save_reward_file("big.py", VALID_SOURCE + padding)
+
+
+def test_save_overwrites_existing_name(service):
+    first = service.save_reward_file("my_rewards.py", VALID_SOURCE)
+    assert len(first.functions) == 3
+
+    replacement = (
+        b"from mlx_lm_lora.trainer.grpo_reward_functions import register_reward_function\n"
+        b"@register_reward_function()\n"
+        b"def only_reward(prompts, completions, answers, types=None):\n"
+        b"    return [1.0]\n"
+    )
+    second = service.save_reward_file("my_rewards.py", replacement)
+    assert second.name == "my_rewards"
+    assert second.functions == ["only_reward"]
+
+    files = service.list_reward_files()
+    assert [f.name for f in files] == ["my_rewards"]
+    assert files[0].functions == ["only_reward"]
+
+
+# --------------------------------------------------------------------- list
+
+
+def test_list_empty_when_no_files(service):
+    assert service.list_reward_files() == []
+
+
+def test_list_sorted_by_name_and_skips_corrupted(service, settings):
+    service.save_reward_file("zeta.py", VALID_SOURCE)
+    service.save_reward_file("alpha.py", VALID_SOURCE)
+    # Corrupted-on-disk file (never uploadable through the API): the listing
+    # must skip it rather than 500.
+    (settings.rewards_dir / "corrupted.py").write_bytes(b"\xff\xfe def broken(:")
+
+    files = service.list_reward_files()
+    assert [f.name for f in files] == ["alpha", "zeta"]
+
+
+# ------------------------------------------------------------------- delete
+
+
+def _grpo_config(**overrides) -> TrainingConfig:
+    base = dict(
+        name="grpo-run",
+        model_id="mlx-community/Tiny-1",
+        dataset_id="ds_1",
+        train_mode="grpo",
+        group_size=4,
+    )
+    base.update(overrides)
+    return TrainingConfig(**base)
+
+
+async def _seed_run(settings, config: TrainingConfig, status: str = "queued") -> None:
+    await init_db(settings.db_path)
+    async with aiosqlite.connect(settings.db_path) as conn:
+        await RunsRepo(conn).insert(
+            run_id="run_active",
+            name=config.name,
+            status=status,
+            config_json=config.model_dump_json(),
+            model_id=config.model_id,
+            dataset_id=config.dataset_id,
+            train_mode=config.train_mode.value,
+            created_at="2026-07-20T00:00:00Z",
+        )
+
+
+@pytest.fixture
+async def runs_repo(settings):
+    await init_db(settings.db_path)
+    async with aiosqlite.connect(settings.db_path) as conn:
+        conn.row_factory = aiosqlite.Row
+        yield RunsRepo(conn)
+
+
+async def test_delete_missing_raises_404(service, runs_repo):
+    with pytest.raises(NotFoundError):
+        await service.delete_reward_file(runs_repo, "nope")
+
+
+async def test_delete_removes_file(service, settings, runs_repo):
+    service.save_reward_file("my_rewards.py", VALID_SOURCE)
+    await service.delete_reward_file(runs_repo, "my_rewards")
+    assert not (settings.rewards_dir / "my_rewards.py").exists()
+    assert service.list_reward_files() == []
+
+
+async def test_delete_accepts_optional_py_suffix(service, settings, runs_repo):
+    service.save_reward_file("my_rewards.py", VALID_SOURCE)
+    await service.delete_reward_file(runs_repo, "my_rewards.py")
+    assert not (settings.rewards_dir / "my_rewards.py").exists()
+
+
+async def test_delete_referenced_by_active_run_raises_409(service, settings):
+    service.save_reward_file("my_rewards.py", VALID_SOURCE)
+    await _seed_run(settings, _grpo_config(reward_functions_file="my_rewards"))
+
+    async with aiosqlite.connect(settings.db_path) as conn:
+        conn.row_factory = aiosqlite.Row
+        with pytest.raises(ConflictError) as exc_info:
+            await service.delete_reward_file(RunsRepo(conn), "my_rewards")
+    assert exc_info.value.status_code == 409
+    # The file survives a refused delete.
+    assert (settings.rewards_dir / "my_rewards.py").is_file()
+
+
+async def test_delete_unreferenced_file_succeeds_while_run_active(service, settings):
+    service.save_reward_file("my_rewards.py", VALID_SOURCE)
+    service.save_reward_file("other.py", VALID_SOURCE)
+    await _seed_run(settings, _grpo_config(reward_functions_file="my_rewards"))
+
+    async with aiosqlite.connect(settings.db_path) as conn:
+        conn.row_factory = aiosqlite.Row
+        await service.delete_reward_file(RunsRepo(conn), "other")
+    assert not (settings.rewards_dir / "other.py").exists()
+
+
+# ------------------------------------------------------------------ resolve
+
+
+def test_resolve_reward_file_path(service, settings):
+    assert resolve_reward_file_path("my_rewards", settings=settings) is None
+    service.save_reward_file("my_rewards.py", VALID_SOURCE)
+    path = resolve_reward_file_path("my_rewards", settings=settings)
+    assert path == settings.rewards_dir / "my_rewards.py"
+    assert path.is_absolute()

--- a/backend/tests/unit/test_schemas.py
+++ b/backend/tests/unit/test_schemas.py
@@ -262,3 +262,58 @@ class TestRewardFunctionValidation:
     def test_unknown_reward_function_rejected_with_valid_list(self):
         with pytest.raises(ValidationError, match="unknown reward_functions: r1_typo"):
             self._grpo(reward_functions=["r1_count_xml", "r1_typo"])
+
+
+class TestRewardFunctionsFileValidation:
+    def _grpo(self, **overrides):
+        base = dict(
+            name="my-run",
+            model_id="mlx-community/x",
+            dataset_id="ds_1",
+            train_mode="grpo",
+            group_size=4,
+        )
+        base.update(overrides)
+        return TrainingConfig(**base)
+
+    def test_accepted_for_grpo(self):
+        config = self._grpo(reward_functions_file="my_rewards")
+        assert config.reward_functions_file == "my_rewards"
+
+    def test_py_suffix_is_stripped_in_reference(self):
+        config = self._grpo(reward_functions_file="my_rewards.py")
+        assert config.reward_functions_file == "my_rewards"
+
+    def test_rejected_for_non_grpo_modes(self):
+        with pytest.raises(
+            ValidationError, match="reward_functions_file is only accepted for grpo"
+        ):
+            TrainingConfig(
+                name="my-run",
+                model_id="mlx-community/x",
+                dataset_id="ds_1",
+                train_mode="sft",
+                reward_functions_file="my_rewards",
+            )
+
+    @pytest.mark.parametrize(
+        "bad_name",
+        ["../escape", "sub/dir", ".hidden", "-dash", "spa ce", ""],
+    )
+    def test_unsafe_names_rejected(self, bad_name):
+        with pytest.raises(ValidationError, match="reward_functions_file"):
+            self._grpo(reward_functions_file=bad_name)
+
+    def test_custom_file_skips_registry_check_for_reward_functions(self):
+        # The file may register brand-new names, so arbitrary entries are
+        # accepted when a custom file is set (unresolvable names fail the run
+        # at start instead — docs/api.md).
+        config = self._grpo(
+            reward_functions_file="my_rewards",
+            reward_functions=["my_custom_reward", "r1_count_xml"],
+        )
+        assert config.reward_functions == ["my_custom_reward", "r1_count_xml"]
+
+    def test_registry_check_still_applies_without_custom_file(self):
+        with pytest.raises(ValidationError, match="unknown reward_functions: my_custom_reward"):
+            self._grpo(reward_functions=["my_custom_reward"])

--- a/backend/tests/unit/test_training_manager.py
+++ b/backend/tests/unit/test_training_manager.py
@@ -76,6 +76,51 @@ async def test_create_job_missing_train_split_raises_422(settings):
 
 
 @pytest.mark.asyncio
+async def test_create_job_missing_reward_file_raises_422(settings):
+    setup_model_dir(settings)
+    await setup_dataset(settings, fmt="grpo")
+    manager = JobManager(settings=settings, worker_argv_factory=make_worker_argv_factory("happy"))
+    with pytest.raises(ValidationAppError, match="reward file 'my_rewards' not found"):
+        await manager.create_job(
+            make_config(train_mode="grpo", group_size=4, reward_functions_file="my_rewards")
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_job_existing_reward_file_accepted(settings):
+    setup_model_dir(settings)
+    await setup_dataset(settings, fmt="grpo")
+    settings.rewards_dir.mkdir(parents=True, exist_ok=True)
+    (settings.rewards_dir / "my_rewards.py").write_text(
+        "from mlx_lm_lora.trainer.grpo_reward_functions import register_reward_function\n"
+        "@register_reward_function()\n"
+        "def my_reward(prompts, completions, answers, types=None):\n"
+        "    return [1.0]\n"
+    )
+    manager = JobManager(
+        settings=settings,
+        worker_argv_factory=make_worker_argv_factory(
+            "happy", FAKE_WORKER_ITERS=1, FAKE_WORKER_STEP_DELAY=0.0
+        ),
+    )
+
+    summary = await manager.create_job(
+        make_config(
+            train_mode="grpo",
+            group_size=4,
+            reward_functions_file="my_rewards",
+            reward_functions=["my_reward"],
+            iters=1,
+        )
+    )
+    assert summary.config.reward_functions_file == "my_rewards"
+    await _run_to_completion(manager, summary.run_id)
+
+    final = await manager.get_run(summary.run_id)
+    assert final.status.value == "completed"
+
+
+@pytest.mark.asyncio
 async def test_create_job_incompatible_dataset_format_raises_422(settings):
     setup_model_dir(settings)
     await setup_dataset(settings, fmt="dpo")

--- a/backend/tests/unit/test_training_worker.py
+++ b/backend/tests/unit/test_training_worker.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import json
+from pathlib import Path
 
 import pytest
 
@@ -74,6 +75,7 @@ class FakeTrainModuleWithLibraryDefaults(FakeTrainModule):
         parser.add_argument("--lambda-mse", type=float, default=0.4)
         parser.add_argument("--clip-epsilon-logits", type=float, default=2.0)
         parser.add_argument("--gradient-accumulation-steps", type=int, default=1)
+        parser.add_argument("--reward-functions-file", type=str, default=None)
         return parser
 
 
@@ -150,6 +152,37 @@ def test_build_worker_args_joins_reward_functions(settings, tmp_path):
 
     assert args.reward_functions == "r1_accuracy_reward_func,r1_count_xml"
     assert args.group_size == 4
+
+
+def test_build_worker_args_forwards_reward_functions_file_as_absolute_path(settings, tmp_path):
+    run_dir = tmp_path / "runs" / "run_reward_file"
+    run_dir.mkdir(parents=True)
+    config = make_config(
+        train_mode="grpo",
+        group_size=4,
+        reward_functions_file="my_rewards",
+        reward_functions=["my_custom_reward"],
+    )
+
+    args = worker._build_worker_args(run_dir, config, train_mod=FakeTrainModule)
+
+    assert args.reward_functions_file == str(settings.rewards_dir / "my_rewards.py")
+    assert Path(args.reward_functions_file).is_absolute()
+    # The names join is unaffected by the file being set.
+    assert args.reward_functions == "my_custom_reward"
+
+
+def test_build_worker_args_reward_functions_file_absent_when_unset(settings, tmp_path):
+    run_dir = tmp_path / "runs" / "run_no_reward_file"
+    run_dir.mkdir(parents=True)
+    config = make_config(train_mode="grpo", group_size=4)
+
+    args = worker._build_worker_args(
+        run_dir, config, train_mod=FakeTrainModuleWithLibraryDefaults
+    )
+
+    # The library's own parser default (None) must survive untouched.
+    assert args.reward_functions_file is None
 
 
 @pytest.mark.parametrize(

--- a/docs/api.md
+++ b/docs/api.md
@@ -179,7 +179,7 @@ partial temp output is removed). `409 conflict` if already terminal; `404` if un
   "gradient_accumulation_steps": null,
   "beta": null, "group_size": null, "temperature": null,
   "max_completion_length": null, "reward_functions": null,
-  "sft_loss_type": null,
+  "reward_functions_file": null, "sft_loss_type": null,
   "lambda_mse_target": null, "tau_mse_target": null,
   "lambda_mse": null, "clip_epsilon_logits": null
 }
@@ -193,7 +193,14 @@ accepted for `ftpo` and are all optional (null → library defaults 0.05 / 1.0 /
 `reward_functions` entries must come from the mlx-lm-lora 3.0.0 registry —
 `r1_accuracy_reward_func | r1_int_reward_func | r1_strict_format_reward_func |
 r1_soft_format_reward_func | r1_count_xml` — unknown names → 422; null or `[]` →
-the library's default set (all five).
+the library's default set (all five). Exception: when `reward_functions_file`
+is set, the registry check is skipped (the file may register new names; an
+unresolvable name then fails the run at start, reported on the run).
+`reward_functions_file` is only accepted for `grpo`: the NAME of an uploaded
+reward file (see /train/reward-files below; same safe-name charset as export
+names, `.py` extension optional in the reference). null → no custom file.
+POST /train/jobs returns 422 `validation_error` if the referenced file does
+not exist.
 Dataset format must be compatible with mode (sft: chat/completions/text; dpo/cpo: dpo;
 orpo: orpo|dpo; grpo: grpo; ftpo: ftpo) → else 422.
 
@@ -215,6 +222,25 @@ orpo: orpo|dpo; grpo: grpo; ftpo: ftpo) → else 422.
 ### GET /train/jobs/{run_id}/metrics?after_step=0&kind=train|val
 `{"metrics": [MetricEvent]}` — persisted metrics for backfill/history.
 ### GET /train/jobs/{run_id}/logs?tail=200 → `{"lines": ["..."]}`
+
+### Custom GRPO reward files
+
+Python files whose functions are decorated with mlx-lm-lora's
+`@register_reward_function()`. Stored under `MLXLF_DATA_DIR/rewards/` and
+referenced by name from `TrainingConfig.reward_functions_file`. The training
+worker EXECUTES the file at run start (this is a local, single-user tool —
+uploading a file is equivalent to running your own script). Function discovery
+for listing purposes is STATIC (AST scan) — the API never executes the file.
+
+### POST /train/reward-files — multipart: `file` (.py)
+→ `201 {"name": "my_rewards", "functions": ["my_reward", ...], "uploaded_at": "..."}`
+Name = the uploaded filename's stem, safe-name charset (`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`
+before the `.py`); re-uploading the same name overwrites. 422 `validation_error`:
+bad name, not parseable Python (syntax error), or no `@register_reward_function`-decorated
+function found. Size cap 256 KiB.
+### GET /train/reward-files → `{"files": [{"name": "...", "functions": [...], "uploaded_at": "..."}]}`
+### DELETE /train/reward-files/{name} → `204`; `409 conflict` if the active
+(queued/running) run's config references it.
 
 ### GET /train/jobs/{run_id}/config.yaml
 Downloads the run's full configuration as YAML (`Content-Type: application/x-yaml`,

--- a/frontend/src/api/queries/keys.ts
+++ b/frontend/src/api/queries/keys.ts
@@ -22,6 +22,7 @@ export const queryKeys = {
     metrics: (id: string, afterStep?: number, kind?: string) =>
       ['training', 'metrics', id, afterStep, kind] as const,
     logs: (id: string, tail?: number) => ['training', 'logs', id, tail] as const,
+    rewardFiles: ['training', 'reward-files'] as const,
   },
   history: {
     list: (

--- a/frontend/src/api/queries/training.ts
+++ b/frontend/src/api/queries/training.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { apiClient } from '../client'
-import type { MetricEvent, RunSummary, TrainingConfig } from '../types'
+import type { MetricEvent, RewardFileInfo, RunSummary, TrainingConfig } from '../types'
 import { queryKeys } from './keys'
 
 const TRAINING_RUNS_PREFIX = ['training', 'runs'] as const
@@ -81,6 +81,38 @@ export function useImportTrainingConfig() {
       const formData = new FormData()
       formData.set('file', file)
       return apiClient.post<TrainingConfig>('/train/configs/import', formData)
+    },
+  })
+}
+
+export function useRewardFiles() {
+  return useQuery({
+    queryKey: queryKeys.training.rewardFiles,
+    queryFn: () => apiClient.get<{ files: RewardFileInfo[] }>('/train/reward-files'),
+  })
+}
+
+export function useUploadRewardFile() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (file: File) => {
+      const formData = new FormData()
+      formData.set('file', file)
+      return apiClient.post<RewardFileInfo>('/train/reward-files', formData)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.training.rewardFiles })
+    },
+  })
+}
+
+export function useDeleteRewardFile() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (name: string) =>
+      apiClient.delete<void>(`/train/reward-files/${encodeURIComponent(name)}`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.training.rewardFiles })
     },
   })
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -199,6 +199,11 @@ export interface TrainingConfig {
   temperature: number | null
   max_completion_length: number | null
   reward_functions: string[] | null
+  // grpo-only (422 otherwise): name of an uploaded reward file (see
+  // /train/reward-files). When set, `reward_functions` may contain any names
+  // (the server skips the registry check — the file may register new ones);
+  // null → no custom file, only the five built-ins are valid.
+  reward_functions_file: string | null
   // sft-only (422 otherwise); null → library default 'nll'.
   sft_loss_type: SftLossType | null
   // ftpo-only (422 otherwise); null → library defaults 0.05 / 1.0 / 0.4 / 2.0.
@@ -206,6 +211,14 @@ export interface TrainingConfig {
   tau_mse_target: number | null
   lambda_mse: number | null
   clip_epsilon_logits: number | null
+}
+
+// Custom GRPO reward file (POST/GET /train/reward-files). `functions` are the
+// `@register_reward_function()`-decorated names discovered by a static AST scan.
+export interface RewardFileInfo {
+  name: string
+  functions: string[]
+  uploaded_at: string
 }
 
 export interface RunSummary {

--- a/frontend/src/components/history/ConfigViewer.tsx
+++ b/frontend/src/components/history/ConfigViewer.tsx
@@ -62,6 +62,7 @@ function buildGroups(config: TrainingConfig): ConfigGroup[] {
         ['temperature', config.temperature],
         ['max_completion_length', config.max_completion_length],
         ['reward_functions', config.reward_functions],
+        ['reward_functions_file', config.reward_functions_file],
         ['sft_loss_type', config.sft_loss_type],
         ['lambda_mse_target', config.lambda_mse_target],
         ['tau_mse_target', config.tau_mse_target],

--- a/frontend/src/components/training/TrainConfigForm.test.tsx
+++ b/frontend/src/components/training/TrainConfigForm.test.tsx
@@ -1,21 +1,27 @@
 import { describe, expect, it, vi } from 'vitest'
 import { fireEvent, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { http, HttpResponse } from 'msw'
+import { http, HttpResponse, type RequestHandler } from 'msw'
 import { server } from '../../test/server'
 import { renderWithProviders } from '../../test/render'
+import type { RewardFileInfo } from '../../api/types'
 import { ToastProvider } from '../common/Toast'
 import { TrainConfigForm } from './TrainConfigForm'
 import { DEFAULT_TRAINING_CONFIG } from './defaults'
 import {
+  deleteRewardFileConflictHandler,
+  deleteRewardFileHandler,
   ftpoDataset,
   grpoDataset,
   importConfigHandler,
   importConfigInvalidHandler,
+  makeRewardFile,
   makeRunSummary,
+  rewardFilesHandler,
   splitDataset,
   trainingHandlers,
   trainModel,
+  uploadRewardFileInvalidHandler,
 } from '../../test/handlers/training'
 
 function renderForm(onCreated = vi.fn()) {
@@ -713,6 +719,259 @@ describe('TrainConfigForm', () => {
     expect(screen.getByRole('checkbox', { name: /r1_count_xml/ })).toBeChecked()
     expect(screen.getByRole('checkbox', { name: /r1_int_reward_func/ })).not.toBeChecked()
     expect(await screen.findByText('Config loaded from YAML.')).toBeInTheDocument()
+  })
+
+  describe('custom GRPO reward files', () => {
+    // Handlers passed here are listed BEFORE trainingHandlers in a single
+    // server.use call, so they win over trainingHandlers' empty
+    // reward-files default (first-registered-in-call matches first in MSW).
+    function renderFormWithHandlers(extra: RequestHandler[], onCreated = vi.fn()) {
+      server.use(...extra, ...trainingHandlers)
+      const result = renderWithProviders(
+        <ToastProvider>
+          <TrainConfigForm onCreated={onCreated} />
+        </ToastProvider>,
+      )
+      return { onCreated, ...result }
+    }
+
+    function capturePost() {
+      const captured: { body: unknown } = { body: null }
+      const handler = http.post('/api/v1/train/jobs', async ({ request }) => {
+        captured.body = await request.json()
+        return HttpResponse.json(makeRunSummary({ run_id: 'run_captured' }), { status: 201 })
+      })
+      return { captured, handler }
+    }
+
+    async function fillGrpoRequiredFields(user: ReturnType<typeof userEvent.setup>) {
+      await user.type(screen.getByLabelText('Run name'), 'my-grpo-run')
+      await user.click(screen.getByRole('radio', { name: new RegExp(trainModel.model_id) }))
+      await user.click(screen.getByRole('radio', { name: /my-grpo-data/ }))
+    }
+
+    it('shows the custom reward file row for grpo only, defaulting to None', async () => {
+      const user = userEvent.setup()
+      renderFormWithHandlers([rewardFilesHandler([makeRewardFile()])])
+      await waitForPickersLoaded()
+
+      expect(screen.queryByLabelText('Custom reward file')).not.toBeInTheDocument()
+
+      await user.click(screen.getByRole('radio', { name: 'GRPO' }))
+
+      const select = screen.getByLabelText('Custom reward file')
+      expect(select).toHaveValue('')
+      await waitFor(() =>
+        expect(screen.getByRole('option', { name: 'my_rewards.py' })).toBeInTheDocument(),
+      )
+      expect(screen.getByRole('button', { name: 'Upload .py' })).toBeInTheDocument()
+      // No file selected yet: only the five built-in checkboxes, default hint.
+      expect(screen.getAllByRole('checkbox')).toHaveLength(5)
+      expect(screen.getByText('None selected → library default (all five).')).toBeInTheDocument()
+    })
+
+    it('selecting a file renders its functions as additional checkboxes and updates the hint', async () => {
+      const user = userEvent.setup()
+      renderFormWithHandlers([rewardFilesHandler([makeRewardFile()])])
+      await waitForPickersLoaded()
+
+      await user.click(screen.getByRole('radio', { name: 'GRPO' }))
+      await waitFor(() =>
+        expect(screen.getByRole('option', { name: 'my_rewards.py' })).toBeInTheDocument(),
+      )
+      await user.selectOptions(screen.getByLabelText('Custom reward file'), 'my_rewards')
+
+      expect(screen.getByText('from my_rewards.py')).toBeInTheDocument()
+      expect(screen.getAllByRole('checkbox')).toHaveLength(7)
+      expect(screen.getByRole('checkbox', { name: /exact_match_reward/ })).not.toBeChecked()
+      expect(screen.getByRole('checkbox', { name: /length_penalty_reward/ })).not.toBeChecked()
+      expect(
+        screen.getByText('None selected → library default (all five built-ins).'),
+      ).toBeInTheDocument()
+    })
+
+    it('submits checked built-ins then customs in stable order, with reward_functions_file set', async () => {
+      const user = userEvent.setup()
+      const { captured, handler } = capturePost()
+      const { onCreated } = renderFormWithHandlers([rewardFilesHandler([makeRewardFile()]), handler])
+      await waitForPickersLoaded()
+
+      await user.click(screen.getByRole('radio', { name: 'GRPO' }))
+      await waitFor(() =>
+        expect(screen.getByRole('option', { name: 'my_rewards.py' })).toBeInTheDocument(),
+      )
+      await user.selectOptions(screen.getByLabelText('Custom reward file'), 'my_rewards')
+
+      // Click in scrambled order — the submitted array must still be
+      // built-ins (registry order) first, then customs (file order).
+      await user.click(screen.getByRole('checkbox', { name: /length_penalty_reward/ }))
+      await user.click(screen.getByRole('checkbox', { name: /r1_count_xml/ }))
+      await user.click(screen.getByRole('checkbox', { name: /exact_match_reward/ }))
+      await user.click(screen.getByRole('checkbox', { name: /r1_accuracy_reward_func/ }))
+
+      await fillGrpoRequiredFields(user)
+      await user.click(screen.getByRole('button', { name: 'Start training' }))
+
+      await waitFor(() => expect(onCreated).toHaveBeenCalledWith('run_captured'))
+      expect(captured.body).toMatchObject({
+        train_mode: 'grpo',
+        dataset_id: grpoDataset.dataset_id,
+        reward_functions_file: 'my_rewards',
+        reward_functions: [
+          'r1_accuracy_reward_func',
+          'r1_count_xml',
+          'exact_match_reward',
+          'length_penalty_reward',
+        ],
+      })
+    })
+
+    it('switching grpo → sft clears reward_functions_file (submits null)', async () => {
+      const user = userEvent.setup()
+      const { captured, handler } = capturePost()
+      const { onCreated } = renderFormWithHandlers([rewardFilesHandler([makeRewardFile()]), handler])
+      await waitForPickersLoaded()
+
+      await user.click(screen.getByRole('radio', { name: 'GRPO' }))
+      await waitFor(() =>
+        expect(screen.getByRole('option', { name: 'my_rewards.py' })).toBeInTheDocument(),
+      )
+      await user.selectOptions(screen.getByLabelText('Custom reward file'), 'my_rewards')
+      await user.click(screen.getByRole('checkbox', { name: /exact_match_reward/ }))
+
+      await user.click(screen.getByRole('radio', { name: 'SFT' }))
+      expect(screen.queryByLabelText('Custom reward file')).not.toBeInTheDocument()
+
+      await user.type(screen.getByLabelText('Run name'), 'back-to-sft')
+      await user.click(screen.getByRole('radio', { name: new RegExp(trainModel.model_id) }))
+      await user.click(screen.getByRole('radio', { name: /my-chat-data/ }))
+      await user.click(screen.getByRole('button', { name: 'Start training' }))
+
+      await waitFor(() => expect(onCreated).toHaveBeenCalledWith('run_captured'))
+      expect(captured.body).toMatchObject({
+        train_mode: 'sft',
+        reward_functions: null,
+        reward_functions_file: null,
+      })
+    })
+
+    it('deselecting the file removes custom names from the submitted config, keeping built-ins', async () => {
+      const user = userEvent.setup()
+      const { captured, handler } = capturePost()
+      const { onCreated } = renderFormWithHandlers([rewardFilesHandler([makeRewardFile()]), handler])
+      await waitForPickersLoaded()
+
+      await user.click(screen.getByRole('radio', { name: 'GRPO' }))
+      await waitFor(() =>
+        expect(screen.getByRole('option', { name: 'my_rewards.py' })).toBeInTheDocument(),
+      )
+      await user.selectOptions(screen.getByLabelText('Custom reward file'), 'my_rewards')
+      await user.click(screen.getByRole('checkbox', { name: /exact_match_reward/ }))
+      await user.click(screen.getByRole('checkbox', { name: /r1_int_reward_func/ }))
+
+      await user.selectOptions(screen.getByLabelText('Custom reward file'), '')
+      expect(screen.queryByText('from my_rewards.py')).not.toBeInTheDocument()
+      expect(screen.getAllByRole('checkbox')).toHaveLength(5)
+      expect(screen.getByRole('checkbox', { name: /r1_int_reward_func/ })).toBeChecked()
+
+      await fillGrpoRequiredFields(user)
+      await user.click(screen.getByRole('button', { name: 'Start training' }))
+
+      await waitFor(() => expect(onCreated).toHaveBeenCalledWith('run_captured'))
+      expect(captured.body).toMatchObject({
+        train_mode: 'grpo',
+        reward_functions: ['r1_int_reward_func'],
+        reward_functions_file: null,
+      })
+    })
+
+    it('upload happy path: 201 → success toast, auto-select, functions appear', async () => {
+      const user = userEvent.setup()
+      const uploaded = makeRewardFile()
+      const files: RewardFileInfo[] = []
+      renderFormWithHandlers([
+        http.get('/api/v1/train/reward-files', () => HttpResponse.json({ files })),
+        http.post('/api/v1/train/reward-files', () => {
+          files.push(uploaded)
+          return HttpResponse.json(uploaded, { status: 201 })
+        }),
+      ])
+      await waitForPickersLoaded()
+
+      await user.click(screen.getByRole('radio', { name: 'GRPO' }))
+      const pyFile = new File(['def my_reward(): ...\n'], 'my_rewards.py', {
+        type: 'text/x-python',
+      })
+      await user.upload(screen.getByLabelText('Reward functions Python file'), pyFile)
+
+      expect(await screen.findByText('Reward file "my_rewards" uploaded.')).toBeInTheDocument()
+      expect(screen.getByLabelText('Custom reward file')).toHaveValue('my_rewards')
+      // The invalidated list refetch delivers the file's functions.
+      expect(await screen.findByText('from my_rewards.py')).toBeInTheDocument()
+      expect(screen.getByRole('checkbox', { name: /exact_match_reward/ })).toBeInTheDocument()
+    })
+
+    it('upload 422 surfaces the backend message and keeps None selected', async () => {
+      const user = userEvent.setup()
+      renderFormWithHandlers([
+        uploadRewardFileInvalidHandler(
+          'no @register_reward_function-decorated function found in bad.py',
+        ),
+      ])
+      await waitForPickersLoaded()
+
+      await user.click(screen.getByRole('radio', { name: 'GRPO' }))
+      const pyFile = new File(['x = 1\n'], 'bad.py', { type: 'text/x-python' })
+      await user.upload(screen.getByLabelText('Reward functions Python file'), pyFile)
+
+      expect(await screen.findByRole('alert')).toHaveTextContent(
+        'no @register_reward_function-decorated function found in bad.py',
+      )
+      expect(screen.getByLabelText('Custom reward file')).toHaveValue('')
+    })
+
+    it('deleting the selected file shows a toast and resets the selection to None', async () => {
+      const user = userEvent.setup()
+      renderFormWithHandlers([
+        rewardFilesHandler([makeRewardFile()]),
+        deleteRewardFileHandler(),
+      ])
+      await waitForPickersLoaded()
+
+      await user.click(screen.getByRole('radio', { name: 'GRPO' }))
+      await waitFor(() =>
+        expect(screen.getByRole('option', { name: 'my_rewards.py' })).toBeInTheDocument(),
+      )
+      await user.selectOptions(screen.getByLabelText('Custom reward file'), 'my_rewards')
+
+      await user.click(screen.getByRole('button', { name: 'Delete file' }))
+
+      expect(await screen.findByText('Reward file "my_rewards" deleted.')).toBeInTheDocument()
+      expect(screen.getByLabelText('Custom reward file')).toHaveValue('')
+    })
+
+    it('delete 409 (active run references the file) surfaces the backend message via toast', async () => {
+      const user = userEvent.setup()
+      renderFormWithHandlers([
+        rewardFilesHandler([makeRewardFile()]),
+        deleteRewardFileConflictHandler('the active run references this reward file'),
+      ])
+      await waitForPickersLoaded()
+
+      await user.click(screen.getByRole('radio', { name: 'GRPO' }))
+      await waitFor(() =>
+        expect(screen.getByRole('option', { name: 'my_rewards.py' })).toBeInTheDocument(),
+      )
+      await user.selectOptions(screen.getByLabelText('Custom reward file'), 'my_rewards')
+
+      await user.click(screen.getByRole('button', { name: 'Delete file' }))
+
+      expect(
+        await screen.findByText('the active run references this reward file'),
+      ).toBeInTheDocument()
+      // The selection is kept — the file still exists.
+      expect(screen.getByLabelText('Custom reward file')).toHaveValue('my_rewards')
+    })
   })
 
   it('Load YAML: surfaces the backend 422 message naming the offending keys', async () => {

--- a/frontend/src/components/training/TrainConfigForm.tsx
+++ b/frontend/src/components/training/TrainConfigForm.tsx
@@ -2,7 +2,13 @@ import { useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useModels } from '../../api/queries/models'
 import { useDatasets } from '../../api/queries/datasets'
-import { useCreateRun, useImportTrainingConfig } from '../../api/queries/training'
+import {
+  useCreateRun,
+  useDeleteRewardFile,
+  useImportTrainingConfig,
+  useRewardFiles,
+  useUploadRewardFile,
+} from '../../api/queries/training'
 import { ApiError } from '../../api/client'
 import type { LoraParams, SftLossType, TrainingConfig, TrainMode, TrainType } from '../../api/types'
 import { Card } from '../common/Card'
@@ -45,11 +51,26 @@ export function TrainConfigForm({ onCreated, initialConfig }: TrainConfigFormPro
   const [importError, setImportError] = useState<string | null>(null)
   const importInputRef = useRef<HTMLInputElement>(null)
 
+  const rewardFilesQuery = useRewardFiles()
+  const uploadRewardFile = useUploadRewardFile()
+  const deleteRewardFile = useDeleteRewardFile()
+  const [rewardUploadError, setRewardUploadError] = useState<string | null>(null)
+  const rewardFileInputRef = useRef<HTMLInputElement>(null)
+
   const splitDatasets = useMemo(
     () => (datasetsQuery.data?.datasets ?? []).filter((d) => d.splits !== null),
     [datasetsQuery.data],
   )
   const selectedDataset = splitDatasets.find((d) => d.dataset_id === config.dataset_id) ?? null
+
+  const rewardFiles = rewardFilesQuery.data?.files ?? []
+  const selectedRewardFile =
+    rewardFiles.find((f) => f.name === config.reward_functions_file) ?? null
+  // Custom names never duplicate a built-in checkbox: a file function shadowing
+  // a registry name is driven by the built-in checkbox above it.
+  const customRewardFunctions = (selectedRewardFile?.functions ?? []).filter(
+    (name) => !GRPO_REWARD_FUNCTIONS.some((fn) => fn.value === name),
+  )
 
   const errors = validateTrainingConfig(config, selectedDataset?.format ?? null)
   const hasErrors = Object.keys(errors).length > 0
@@ -67,6 +88,7 @@ export function TrainConfigForm({ onCreated, initialConfig }: TrainConfigFormPro
   }
 
   function toggleRewardFunction(name: string) {
+    const fileFunctions = customRewardFunctions
     setConfig((prev) => {
       const selected = new Set(prev.reward_functions ?? [])
       if (selected.has(name)) {
@@ -74,9 +96,68 @@ export function TrainConfigForm({ onCreated, initialConfig }: TrainConfigFormPro
       } else {
         selected.add(name)
       }
-      // Always submit in the fixed registry order, never click order.
-      const ordered = GRPO_REWARD_FUNCTIONS.map((fn) => fn.value).filter((v) => selected.has(v))
+      // Always submit in a stable order, never click order: built-ins in
+      // registry order first, then custom functions in file order.
+      const ordered = [
+        ...GRPO_REWARD_FUNCTIONS.map((fn) => fn.value).filter((v) => selected.has(v)),
+        ...fileFunctions.filter((v) => selected.has(v)),
+      ]
       return { ...prev, reward_functions: ordered.length > 0 ? ordered : null }
+    })
+  }
+
+  /**
+   * Select (or deselect with null) the custom reward file. Custom function
+   * names from the previous file are dropped from `reward_functions` — only
+   * built-in registry names survive a file change.
+   */
+  function selectRewardFile(name: string | null) {
+    setConfig((prev) => {
+      const builtinsOnly = (prev.reward_functions ?? []).filter((v) =>
+        GRPO_REWARD_FUNCTIONS.some((fn) => fn.value === v),
+      )
+      return {
+        ...prev,
+        reward_functions_file: name,
+        reward_functions: builtinsOnly.length > 0 ? builtinsOnly : null,
+      }
+    })
+  }
+
+  function handleRewardFileUpload(files: FileList | null) {
+    const file = files?.[0]
+    // Reset so picking the same file again re-fires the change event.
+    if (rewardFileInputRef.current) rewardFileInputRef.current.value = ''
+    if (!file) return
+    setRewardUploadError(null)
+    uploadRewardFile.mutate(file, {
+      onSuccess: (info) => {
+        toast(`Reward file "${info.name}" uploaded.`, { variant: 'success' })
+        selectRewardFile(info.name)
+      },
+      onError: (error) => {
+        // 422s explain what is wrong (bad name / syntax error / no decorated
+        // function / oversize) — surface the backend message verbatim.
+        setRewardUploadError(
+          error instanceof ApiError ? error.message : 'Failed to upload the reward file.',
+        )
+      },
+    })
+  }
+
+  function handleDeleteRewardFile(name: string) {
+    deleteRewardFile.mutate(name, {
+      onSuccess: () => {
+        toast(`Reward file "${name}" deleted.`, { variant: 'success' })
+        selectRewardFile(null)
+      },
+      onError: (error) => {
+        // 409 conflict when the active run references the file.
+        toast(
+          error instanceof ApiError ? error.message : 'Failed to delete the reward file.',
+          { variant: 'error' },
+        )
+      },
     })
   }
 
@@ -362,6 +443,64 @@ export function TrainConfigForm({ onCreated, initialConfig }: TrainConfigFormPro
           </div>
           <fieldset className="mt-4">
             <legend className="mb-2 block text-sm font-medium text-text">Reward functions</legend>
+            <div className="mb-3 flex flex-col gap-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <Field label="Custom reward file" htmlFor="reward-functions-file" className="min-w-48">
+                  <Select
+                    id="reward-functions-file"
+                    options={[
+                      { value: '', label: 'None' },
+                      ...rewardFiles.map((f) => ({ value: f.name, label: `${f.name}.py` })),
+                      // Keep a referenced-but-missing name visible instead of
+                      // silently snapping the select to "None".
+                      ...(config.reward_functions_file && !selectedRewardFile
+                        ? [
+                            {
+                              value: config.reward_functions_file,
+                              label: `${config.reward_functions_file}.py (missing)`,
+                            },
+                          ]
+                        : []),
+                    ]}
+                    value={config.reward_functions_file ?? ''}
+                    onChange={(e) => selectRewardFile(e.target.value === '' ? null : e.target.value)}
+                  />
+                </Field>
+                <div className="flex items-end gap-2 self-stretch pb-0.5">
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    loading={uploadRewardFile.isPending}
+                    onClick={() => rewardFileInputRef.current?.click()}
+                  >
+                    Upload .py
+                  </Button>
+                  {selectedRewardFile && (
+                    <Button
+                      variant="danger"
+                      size="sm"
+                      loading={deleteRewardFile.isPending}
+                      onClick={() => handleDeleteRewardFile(selectedRewardFile.name)}
+                    >
+                      Delete file
+                    </Button>
+                  )}
+                </div>
+              </div>
+              <input
+                ref={rewardFileInputRef}
+                type="file"
+                accept=".py"
+                className="hidden"
+                aria-label="Reward functions Python file"
+                onChange={(e) => handleRewardFileUpload(e.target.files)}
+              />
+              {rewardUploadError && (
+                <p role="alert" className="text-xs text-danger">
+                  {rewardUploadError}
+                </p>
+              )}
+            </div>
             <div className="flex flex-col gap-2">
               {GRPO_REWARD_FUNCTIONS.map((fn) => (
                 <label
@@ -382,8 +521,30 @@ export function TrainConfigForm({ onCreated, initialConfig }: TrainConfigFormPro
                 </label>
               ))}
             </div>
+            {selectedRewardFile && customRewardFunctions.length > 0 && (
+              <div className="mt-3">
+                <p className="mb-2 text-xs font-medium text-text-muted">
+                  from {selectedRewardFile.name}.py
+                </p>
+                <div className="flex flex-col gap-2">
+                  {customRewardFunctions.map((name) => (
+                    <label key={name} className="flex items-center gap-2 text-sm text-text" title={name}>
+                      <input
+                        type="checkbox"
+                        checked={(config.reward_functions ?? []).includes(name)}
+                        onChange={() => toggleRewardFunction(name)}
+                        className="h-4 w-4 accent-accent"
+                      />
+                      <code className="font-mono text-xs">{name}</code>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            )}
             <p className="mt-2 text-xs text-text-muted">
-              None selected → library default (all five).
+              {selectedRewardFile
+                ? 'None selected → library default (all five built-ins).'
+                : 'None selected → library default (all five).'}
             </p>
           </fieldset>
         </Card>

--- a/frontend/src/components/training/defaults.ts
+++ b/frontend/src/components/training/defaults.ts
@@ -28,6 +28,7 @@ export const DEFAULT_TRAINING_CONFIG: TrainingConfig = {
   temperature: null,
   max_completion_length: null,
   reward_functions: null,
+  reward_functions_file: null,
   sft_loss_type: null,
   lambda_mse_target: null,
   tau_mse_target: null,
@@ -65,6 +66,7 @@ type ModeSpecificFields = Pick<
   | 'temperature'
   | 'max_completion_length'
   | 'reward_functions'
+  | 'reward_functions_file'
   | 'sft_loss_type'
   | 'lambda_mse_target'
   | 'tau_mse_target'
@@ -78,6 +80,9 @@ const MODE_FIELDS_CLEARED: ModeSpecificFields = {
   temperature: null,
   max_completion_length: null,
   reward_functions: null,
+  // grpo-only, like reward_functions: cleared on every mode switch so a
+  // custom file never leaks into a non-grpo config (the backend 422s).
+  reward_functions_file: null,
   sft_loss_type: null,
   lambda_mse_target: null,
   tau_mse_target: null,

--- a/frontend/src/test/handlers.ts
+++ b/frontend/src/test/handlers.ts
@@ -49,6 +49,7 @@ export const handlers = [
   // Empty-list defaults so route-level smoke tests can render every page
   // without per-test overrides (pages fetch these on mount).
   http.get('/api/v1/datasets', () => HttpResponse.json({ datasets: [] })),
+  http.get('/api/v1/train/reward-files', () => HttpResponse.json({ files: [] })),
   http.get('/api/v1/adapters', () => HttpResponse.json({ adapters: [] })),
   http.get('/api/v1/export/artifacts', () => HttpResponse.json({ artifacts: [] })),
   http.get('/api/v1/models/downloads', () => HttpResponse.json({ downloads: [] })),

--- a/frontend/src/test/handlers/dashboard.ts
+++ b/frontend/src/test/handlers/dashboard.ts
@@ -60,6 +60,7 @@ export function makeRunSummary(overrides: Partial<RunSummary> = {}): RunSummary 
       temperature: null,
       max_completion_length: null,
       reward_functions: null,
+      reward_functions_file: null,
       sft_loss_type: null,
       lambda_mse_target: null,
       tau_mse_target: null,

--- a/frontend/src/test/handlers/training.ts
+++ b/frontend/src/test/handlers/training.ts
@@ -1,5 +1,11 @@
 import { http, HttpResponse } from 'msw'
-import type { DatasetInfo, ModelInfo, RunSummary, TrainingConfig } from '../../api/types'
+import type {
+  DatasetInfo,
+  ModelInfo,
+  RewardFileInfo,
+  RunSummary,
+  TrainingConfig,
+} from '../../api/types'
 
 // Additional MSW handlers for Train-page tests (TrainConfigForm, RunMonitor,
 // TrainPage). These are additive overrides applied per-test via
@@ -88,6 +94,7 @@ export function makeRunSummary(overrides: Partial<RunSummary> = {}): RunSummary 
       temperature: null,
       max_completion_length: null,
       reward_functions: null,
+      reward_functions_file: null,
       sft_loss_type: null,
       lambda_mse_target: null,
       tau_mse_target: null,
@@ -122,10 +129,59 @@ export function importConfigInvalidHandler(
   )
 }
 
+export function makeRewardFile(overrides: Partial<RewardFileInfo> = {}): RewardFileInfo {
+  return {
+    name: 'my_rewards',
+    functions: ['exact_match_reward', 'length_penalty_reward'],
+    uploaded_at: '2026-07-12T10:00:00Z',
+    ...overrides,
+  }
+}
+
+/** GET /train/reward-files listing the given files (default: none uploaded). */
+export function rewardFilesHandler(files: RewardFileInfo[] = []) {
+  return http.get('/api/v1/train/reward-files', () => HttpResponse.json({ files }))
+}
+
+/** POST /train/reward-files happy path → 201 with the given file info. */
+export function uploadRewardFileHandler(info: RewardFileInfo = makeRewardFile()) {
+  return http.post('/api/v1/train/reward-files', () => HttpResponse.json(info, { status: 201 }))
+}
+
+/** POST /train/reward-files 422 (bad name / bad python / no decorated function / oversize). */
+export function uploadRewardFileInvalidHandler(
+  message = 'no @register_reward_function-decorated function found',
+) {
+  return http.post('/api/v1/train/reward-files', () =>
+    HttpResponse.json(
+      { error: { code: 'validation_error', message, detail: {} } },
+      { status: 422 },
+    ),
+  )
+}
+
+/** DELETE /train/reward-files/{name} happy path → 204. */
+export function deleteRewardFileHandler() {
+  return http.delete(
+    '/api/v1/train/reward-files/:name',
+    () => new HttpResponse(null, { status: 204 }),
+  )
+}
+
+/** DELETE /train/reward-files/{name} 409 — the active run references the file. */
+export function deleteRewardFileConflictHandler(
+  message = 'the active run references this reward file',
+) {
+  return http.delete('/api/v1/train/reward-files/:name', () =>
+    HttpResponse.json({ error: { code: 'conflict', message, detail: {} } }, { status: 409 }),
+  )
+}
+
 export const trainingHandlers = [
   http.get('/api/v1/datasets', () =>
     HttpResponse.json({ datasets: [splitDataset, ftpoDataset, grpoDataset, unsplitDataset] }),
   ),
+  rewardFilesHandler(),
   http.get('/api/v1/train/jobs/:runId/metrics', () => HttpResponse.json({ metrics: [] })),
   http.get('/api/v1/train/jobs/:runId/logs', () => HttpResponse.json({ lines: [] })),
   http.post('/api/v1/train/jobs/:runId/cancel', ({ params }) =>


### PR DESCRIPTION
Week-A wave, part 2 (A3): GRPO is no longer limited to the five built-in `r1_*` rewards — you can now bring your own reward functions as a Python file. Three commits, contract-first.

## Contract (`6b73cb9`)

- **`POST /train/reward-files`** (multipart `.py`) → `201 {name, functions, uploaded_at}`. Function discovery is **static** — an AST scan for `@register_reward_function`-decorated defs; **the API never executes the file**. 422 for bad name, unparseable Python, no decorated functions, or oversize.
- **`GET /train/reward-files`** / **`DELETE /train/reward-files/{name}`** (409 while the active run references it).
- **`TrainingConfig.reward_functions_file`** — grpo-only, references an uploaded file by name (`.py` optional). When set, the registry name check on `reward_functions` is skipped (the file may register new names; an unresolvable one fails the run at start). Job submit 422s if the file is missing.
- Execution is explicit and documented: only the **training worker** executes the file at run start — in a local single-user tool this is equivalent to running your own script.

## Backend (`f786484`)

New `rewards_dir` under the data dir; `reward_files_service` (stdlib-`ast` discovery handling plain/called/`name=`-kwarg decorator forms; listing tolerates corrupted files); small dedicated router; schema normalization (stores the stem) + conditional validation; existence check inside `create_job`'s locked section; worker passes the absolute path through. Delete's 409 guard reads active runs from the DB (mirrors the dataset-delete guard, survives restarts).

## Frontend (`91e7f21`)

The GRPO card's reward fieldset gains a "Custom reward file" row — select or upload inline (201 auto-selects; 422 shows the backend's message). The file's discovered functions appear as additional checkboxes under a "from `<name>.py`" label; submissions keep a stable order (built-ins first, then customs); switching/deselecting the file strips custom names; leaving grpo clears the field; a referenced-but-missing file shows as "(missing)" instead of silently resetting. YAML export/import carries the new field automatically.

## Tests (+34)

Backend 25 (AST discovery variants, all upload 422s, listing tolerance, delete guards, schema rules incl. registry-skip semantics, manager existence check, worker path forwarding, YAML round-trip) and frontend 9 (file row gating, function checkboxes, submit order, mode clearing, upload happy/422, deselect stripping, delete 409).

## Verification

- `make test`: backend **497** (+45), frontend **272** (+9) — all green
- `make lint` clean; `make build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UEysgYYG512HSnoKf5cgm

---
_Generated by [Claude Code](https://claude.ai/code/session_014UEysgYYG512HSnoKf5cgm)_