### PR TITLE
Release prep: v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The version's source of truth is `backend/pyproject.toml` (reported by
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-23
+
 ### Added
 
 - Training configs export/load as YAML: download any run's full configuration
@@ -19,6 +21,20 @@ The version's source of truth is `backend/pyproject.toml` (reported by
 - README: end-to-end GRPO fine-tuning walkthrough — dataset format, all five
   reward functions explained, a ready-to-load YAML config, and a UI
   screenshot (#48)
+- `gradient_accumulation_steps` exposed end to end for every train mode —
+  effective batch = batch size × accumulation steps (#50)
+- Chat and Fuse actions on saved checkpoints: talk to a mid-training snapshot
+  or open the export wizard prefilled, straight from the run monitor (#50)
+- Custom GRPO reward functions: upload a `.py` file (functions discovered by
+  a static AST scan — the API never executes it), pick its rewards alongside
+  the built-ins, and the training worker loads it at run start (#51)
+
+### Changed
+
+- Frontend upgraded to React 19 (all four react packages together) with a
+  dependabot group so they keep moving as one (#40)
+- Toolchain bumps: TypeScript 7, Vite 8.1.5, oxlint 1.74, @types/node 26,
+  and GitHub Actions majors across both workflows (#29–#37, #46)
 
 ## [0.1.0] - 2026-07-16
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mlx-lora-finetuner-backend"
-version = "0.1.0"
+version = "0.2.0"
 description = "MLX ile LoRA fine-tuning yapan uygulamanın FastAPI backend'i"
 requires-python = ">=3.11"
 # Bounds policy: lower bound = the minor we develop/lock against, upper

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -924,7 +924,7 @@ wheels = [
 
 [[package]]
 name = "mlx-lora-finetuner-backend"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@tanstack/react-query": "^5.101.2",
         "react": "^19.2.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Cuts v0.2.0 per the CONTRIBUTING release steps — one commit:

- **Versions**: backend `pyproject.toml` and frontend `package.json` (+ both locks) bumped 0.1.0 → 0.2.0. `GET /system/health` picks the new version up automatically from the backend package.
- **CHANGELOG**: `[Unreleased]` → `[0.2.0] - 2026-07-23`. **Added**: YAML config export/import (#47), README GRPO walkthrough (#48), gradient accumulation (#50), checkpoint chat/fuse actions (#50), custom GRPO reward files (#51). **Changed**: React 19 migration + dependabot react group (#40), toolchain bumps — TypeScript 7, Vite 8.1.5, oxlint 1.74, @types/node 26, Actions majors (#29–#37, #46).

## After merging

Tag from GitHub (I can't push tags from this session): **Releases → Draft a new release → tag `v0.2.0` (create on publish, target `main`)**, paste the notes below, publish.

```markdown
## v0.2.0 — reproducible experiments & custom rewards

### ✨ New
- **Export/load experiment configs as YAML** — download any run's full
  configuration from History or the run monitor, and load it back into the
  train form with strict validation. Share and reproduce experiments as files.
- **Custom GRPO reward functions** — upload a `.py` file, its
  `@register_reward_function` rewards are discovered safely (static AST scan)
  and selectable next to the five built-ins; the trainer loads them at run start.
- **Gradient accumulation** — larger effective batches on memory-constrained
  Macs (`effective batch = batch size × accumulation steps`), every train mode.
- **Checkpoint actions** — chat with a mid-training snapshot or fuse it,
  straight from the checkpoint list in the run monitor.
- **GRPO walkthrough** in the README — dataset format, all five built-in
  rewards explained, a ready-to-load YAML config and a UI screenshot.

### 🔧 Changed
- React 19, TypeScript 7 and toolchain/CI action upgrades across the board.

Full details in [CHANGELOG.md](CHANGELOG.md).
```

## Verification

- `make test`: backend **497**, frontend **272** — all green with the bumped versions
- `make lint` clean; lock diffs are version-metadata only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UEysgYYG512HSnoKf5cgm

---
_Generated by [Claude Code](https://claude.ai/code/session_014UEysgYYG512HSnoKf5cgm)_