### PR TITLE
README: animated UI demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ A local web studio for LoRA fine-tuning of LLMs on Apple Silicon, built on top o
 React/TypeScript/Vite frontend, similar in spirit to Unsloth Studio but running
 entirely on-device via MLX — no cloud GPUs, no data leaving your Mac.
 
-To see the UI, run it locally: `make run` builds the frontend and serves the
-whole app from a single process on http://127.0.0.1:8000 (see
+![Demo: browsing models and datasets, then configuring a GRPO run](docs/screenshots/demo.gif)
+
+To try it yourself: `make run` builds the frontend and serves the whole app
+from a single process on http://127.0.0.1:8000 (see
 [Production / single-command run](#production--single-command-run)).
 
 ## Features


### PR DESCRIPTION
Adds a 20-second animated demo at the top of the README — the first thing a visitor sees.

Recorded from the **real 0.2.0 UI** (Playwright driving a locally served `make run` build with a seeded model + split GRPO dataset): dashboard → models → datasets → configuring a GRPO run, ending on the reward-functions editor **including the brand-new custom reward file row** from #51. Converted with a two-pass palette pipeline (10 fps, 1100 px, bayer dither) — 4.2 MB, well under GitHub's render limit.

Docs + one asset only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UEysgYYG512HSnoKf5cgm

---
_Generated by [Claude Code](https://claude.ai/code/session_014UEysgYYG512HSnoKf5cgm)_