### PR TITLE
Changelog: record i18n, the release workflow and the README demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ The version's source of truth is `backend/pyproject.toml` (reported by
 
 ## [Unreleased]
 
+### Added
+
+- Full UI internationalization: English and Turkish across every surface
+  (~610 keys), with a persistent EN/TR switcher in the top bar and
+  browser-language detection on first visit (#55)
+- Dispatchable release workflow: one action validates the changelog/version
+  coherence, tags main and publishes the GitHub release (#54)
+- Animated UI demo at the top of the README (#53)
+
 ## [0.2.0] - 2026-07-23
 
 ### Added


### PR DESCRIPTION
Adds the three shipped-since-0.2.0 items to `[Unreleased]`:

- Full EN/TR internationalization with the persistent switcher (#55)
- The dispatchable release workflow (#54)
- The README's animated demo (#53)

Docs-only, single file — these roll into the next version section at release time (the Release workflow will pick them up automatically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UEysgYYG512HSnoKf5cgm

---
_Generated by [Claude Code](https://claude.ai/code/session_014UEysgYYG512HSnoKf5cgm)_