### PR TITLE
Cap ruff at the next minor + group dependabot updates per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,20 @@
 version: 2
+
+# Grouping policy: every bump in an ecosystem rewrites the same lockfile
+# (uv.lock / package-lock.json), so ungrouped PRs conflict with each other
+# the moment one of them merges — each survivor then needs a dependabot
+# rebase round before it can land. Grouping collapses that into one PR per
+# ecosystem per week, which is also one CI run instead of N.
 updates:
   # Backend: uv-managed (backend/pyproject.toml + backend/uv.lock).
   - package-ecosystem: "uv"
     directory: "/backend"
     schedule:
       interval: "weekly"
+    groups:
+      backend:
+        patterns:
+          - "*"
 
   # Frontend: npm (frontend/package.json + package-lock.json).
   - package-ecosystem: "npm"
@@ -14,16 +24,25 @@ updates:
     groups:
       # react and react-dom (and their @types) pin each other via peer
       # deps — bumping them separately always produces an ERESOLVE-broken
-      # PR (see #36/#39), so they must move as one.
+      # PR (see #36/#39), so they must move as one. Kept as its own group
+      # (evaluated before `frontend`) so a React major stays reviewable on
+      # its own instead of riding along with routine patches.
       react:
         patterns:
           - "react"
           - "react-dom"
           - "@types/react"
           - "@types/react-dom"
+      frontend:
+        patterns:
+          - "*"
 
   # GitHub Actions used in .github/workflows/.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -36,7 +36,13 @@ dev = [
     "pytest>=9.1,<10",
     "pytest-asyncio>=1.4,<2",
     "httpx>=0.28,<1",
-    "ruff>=0.15,<1",
+    # Linters are the exception to the bounds policy above: a new ruff MINOR
+    # enables new default rules, which is effectively breaking for `make lint`.
+    # 0.16 alone flags 96 findings here (32 are B008 on FastAPI's own Depends()
+    # idiom), so the ceiling is the next minor, not the next major. Dependabot
+    # still proposes the bump — as a PR we can review rules for, instead of an
+    # incidental `uv lock` refresh silently breaking lint for everyone.
+    "ruff>=0.15.21,<0.16",
 ]
 
 [build-system]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -981,7 +981,7 @@ dev = [
     { name = "httpx", specifier = ">=0.28,<1" },
     { name = "pytest", specifier = ">=9.1,<10" },
     { name = "pytest-asyncio", specifier = ">=1.4,<2" },
-    { name = "ruff", specifier = ">=0.15,<1" },
+    { name = "ruff", specifier = ">=0.15.21,<0.16" },
 ]
 
 [[package]]


### PR DESCRIPTION
Two dependency-hygiene fixes found while verifying the open dependabot PRs. Rebased onto main after #58 landed.

## 1. Cap ruff at the next minor (`73440f2`)

The bounds policy from #25 uses **next-major** ceilings. That's right for libraries but wrong for **linters**: a new ruff *minor* enables new default rules, which breaks `make lint` exactly like a breaking release would.

`ruff>=0.15,<1` meant any routine `uv lock` — adding a single dependency is enough, which I did twice this month — could jump to **0.16.0**, which reports **96 findings** here. 32 are `B008` against FastAPI's own `Depends()` idiom, i.e. not something we'd want to "fix" on an incidental relock.

Reproduced: fresh `uv lock` on main → ruff 0.16.0 → 96 errors. Pinned to 0.15.22 → `All checks passed!`. With the new ceiling a fresh lock stays on 0.15.21 and lint is clean.

Dependabot still proposes ruff bumps as reviewable PRs — they just can't land as an invisible side effect anymore.

## 2. Group dependabot updates per ecosystem (`bcf792a`)

**This is the fix for the conflicts you just hit.** Every bump rewrites the same lockfile, so ungrouped PRs collide as soon as one merges: #58 landing put #61 into a dirty state immediately, and #64 + this PR were queued behind the same collision. That's not a one-off — it happens every week with more than one open PR per ecosystem.

Now: one PR per ecosystem per week (and one CI run instead of N). The `react` group stays separate and is evaluated first, so a React major is still reviewed on its own rather than riding along with routine patches.

## What happens to the currently open PRs

Dependabot closes superseded individual PRs and reopens them as grouped ones on its next run. Two ways to play it:

- **Merge this first** (recommended): let dependabot replace the remaining seven with ~3 grouped PRs — no more rebase rounds this week.
- **Or finish merging one by one** (each needs a `·@·d·ependabot r·ebase` after the previous merge), then take this.

I've already commented `·@·d·ependabot r·ebase` on #61 to unblock it either way. I did not push to its branch — dependabot explicitly disowns a PR that someone else edits.

## Verification

- `make test`: backend **497**, frontend **272**; `make lint` clean; `make build` green
- All nine open dependabot PRs verified **combined** (manifests applied together + locks regenerated): suite, lint (on their target versions) and build all green — they're safe to merge in any order once rebased
- `dependabot.yml` parsed and group resolution checked (`uv → backend`, `npm → react, frontend`, `actions → actions`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UEysgYYG512HSnoKf5cgm