### PR TITLE
fix(export): gate GGUF conversion on the converter's own imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ from a single process on http://127.0.0.1:8000 (see
   train mode, status) with one-click cloning of a past run's config into a
   fresh prefill.
 - **Export** — fuse a LoRA adapter into the base model, convert the fused model to
-  GGUF (with preflight checks for llama.cpp availability, architecture support,
-  and de-quantization), and render an Ollama `Modelfile` ready for `ollama create`.
+  GGUF (with preflight checks for llama.cpp availability, converter
+  dependencies, architecture support, and de-quantization), and render an
+  Ollama `Modelfile` ready for `ollama create`.
 - **Dashboard** — system stats (memory/disk), the active run at a glance, recent
   runs, and an onboarding guide for first-time setup.
 
@@ -182,8 +183,31 @@ All settings are environment variables with an `MLXLF_` prefix (see
 | `MLXLF_HOST`         | `127.0.0.1`                | Backend bind host.                                                  |
 | `MLXLF_PORT`         | `8000`                     | Backend port.                                                       |
 | `MLXLF_HF_TOKEN`     | *(unset)*                  | Hugging Face token, used for gated/private models and higher rate limits. |
-| `MLXLF_LLAMA_CPP_DIR` | *(unset)*                  | Path to a `llama.cpp` checkout containing `convert_hf_to_gguf.py`, required for GGUF export. Falls back to `<data_dir>/cache/llama.cpp`. |
+| `MLXLF_LLAMA_CPP_DIR` | *(unset)*                  | Path to a `llama.cpp` checkout containing `convert_hf_to_gguf.py`, required for GGUF export. Falls back to `<data_dir>/cache/llama.cpp`. See [GGUF export prerequisites](#gguf-export-prerequisites). |
 | `MLXLF_STATIC_DIR`   | `<repo>/frontend/dist`     | Built frontend served at `/` in production (`mlxlf`). If it contains no `index.html`, nothing is mounted (dev mode). |
+
+### GGUF export prerequisites
+
+GGUF conversion shells out to llama.cpp's `convert_hf_to_gguf.py`, running it
+with the backend's own interpreter. Two things must be in place:
+
+1. **The script.** Point `MLXLF_LLAMA_CPP_DIR` at a directory containing
+   `convert_hf_to_gguf.py` (a `llama.cpp` checkout, or `/opt/homebrew/bin` for
+   Homebrew's `llama.cpp`), or clone the repo into `<data_dir>/cache/llama.cpp`.
+2. **Its dependencies**, in the backend environment — the script imports
+   `torch`, `transformers` and `numpy` at module level, plus `gguf` when the
+   directory does not ship its own `gguf-py` (Homebrew's does not):
+
+   ```bash
+   cd backend && uv sync --extra gguf
+   ```
+
+   `make install` already includes this extra. It is optional because `torch`
+   is a large download that nothing else in the app needs.
+
+`GET /export/gguf/preflight` reports both as the `llama_cpp_available` and
+`convert_deps_importable` checks, and `POST /export/gguf` refuses to start
+until they pass.
 
 ### Data directory layout
 

--- a/backend/app/services/export_service.py
+++ b/backend/app/services/export_service.py
@@ -10,6 +10,7 @@ constructor so tests can capture argv without ever spawning a real process.
 from __future__ import annotations
 
 import asyncio
+import importlib.util
 import json
 import sys
 import uuid
@@ -44,9 +45,28 @@ CURATED_ARCHS = {"llama", "qwen2", "qwen3", "mistral", "gemma", "gemma2", "phi3"
 
 MODEL_FAMILIES = {"qwen", "llama", "smollm", "mistral", "custom"}
 
+# Third-party modules `convert_hf_to_gguf.py` imports at module level. They are
+# checked against *this* interpreter because `start_gguf` runs the script with
+# `sys.executable`: finding the script on disk says nothing about whether it
+# can get past its own import block.
+CONVERT_SCRIPT_MODULES = ("torch", "transformers", "numpy")
+
 
 class RunSubprocess(Protocol):
     async def __call__(self, *args: str, **kwargs: Any) -> asyncio.subprocess.Process: ...
+
+
+class ModuleAvailable(Protocol):
+    def __call__(self, module: str) -> bool: ...
+
+
+def _module_available(module: str) -> bool:
+    try:
+        return importlib.util.find_spec(module) is not None
+    except (ImportError, ValueError):
+        # A namespace package with a broken parent raises rather than
+        # returning None; either way the import would fail.
+        return False
 
 
 def _now() -> str:
@@ -66,9 +86,11 @@ class ExportService:
         self,
         settings: Settings,
         run_subprocess: RunSubprocess | None = None,
+        module_available: ModuleAvailable | None = None,
     ) -> None:
         self._settings = settings
         self._run_subprocess: RunSubprocess = run_subprocess or asyncio.create_subprocess_exec
+        self._module_available: ModuleAvailable = module_available or _module_available
         # export_id -> streamed stdout lines for jobs started by this process.
         self._progress_logs: dict[str, list[str]] = {}
         self._jinja_env = Environment(
@@ -121,6 +143,16 @@ class ExportService:
             if (candidate / "convert_hf_to_gguf.py").is_file():
                 return candidate
         return None
+
+    def _missing_convert_modules(self, llama_dir: Path | None) -> list[str]:
+        """Modules `convert_hf_to_gguf.py` needs that this interpreter lacks."""
+        required = list(CONVERT_SCRIPT_MODULES)
+        # A full llama.cpp checkout ships gguf-py and the script prepends it to
+        # sys.path itself, so only a bare install (Homebrew's, say) needs the
+        # published `gguf` package.
+        if llama_dir is None or not (llama_dir / "gguf-py" / "gguf").is_dir():
+            required.append("gguf")
+        return [module for module in required if not self._module_available(module)]
 
     # -- fuse -----------------------------------------------------------
 
@@ -197,6 +229,28 @@ class ExportService:
                         f"convert_hf_to_gguf.py içeren bir dizine ayarlayın ya da llama.cpp "
                         f"deposunu {default_dir} içine klonlayın."
                     ),
+                )
+            )
+
+        missing = self._missing_convert_modules(llama_dir)
+        if missing:
+            checks.append(
+                PreflightCheck(
+                    name="convert_deps_importable",
+                    ok=False,
+                    message=(
+                        f"convert_hf_to_gguf.py şu modülleri {sys.executable} içinde "
+                        f"bulamıyor: {', '.join(missing)}. Backend ortamına kurun: "
+                        "cd backend && uv sync --extra gguf"
+                    ),
+                )
+            )
+        else:
+            checks.append(
+                PreflightCheck(
+                    name="convert_deps_importable",
+                    ok=True,
+                    message="dönüştürme bağımlılıkları hazır",
                 )
             )
 

--- a/backend/app/services/export_service.py
+++ b/backend/app/services/export_service.py
@@ -64,8 +64,10 @@ def _module_available(module: str) -> bool:
     try:
         return importlib.util.find_spec(module) is not None
     except (ImportError, ValueError):
-        # A namespace package with a broken parent raises rather than
-        # returning None; either way the import would fail.
+        # find_spec raises instead of returning None for a missing parent
+        # package or an already-imported module with no __spec__. Neither can
+        # happen for the top-level names asked about here, but a raising
+        # probe must never be louder than the failed import it stands in for.
         return False
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -30,6 +30,14 @@ mlx = [
     "mlx-lm-lora==3.0.0",
     "mlx-lm==0.31.3",
 ]
+# Dependencies of llama.cpp's `convert_hf_to_gguf.py`, which GGUF export runs
+# with this interpreter. Optional because torch is a large download and no
+# other part of the app touches it — everything else runs on MLX.
+gguf = [
+    "torch>=2.13,<3",
+    "transformers>=5.13,<6",
+    "gguf>=0.19,<1",
+]
 
 [dependency-groups]
 dev = [

--- a/backend/tests/integration/test_export_api.py
+++ b/backend/tests/integration/test_export_api.py
@@ -214,12 +214,13 @@ async def test_gguf_preflight_all_green_via_api(client, export_service, data_dir
     assert response.status_code == 200
     data = response.json()
     assert data["ok"] is True
-    assert {c["name"] for c in data["checks"]} == {
+    # Order matters: docs/api.md freezes it as the shape clients render.
+    assert [c["name"] for c in data["checks"]] == [
         "llama_cpp_available",
         "convert_deps_importable",
         "arch_supported",
         "weights_dequantized",
-    }
+    ]
 
 
 @pytest.mark.asyncio
@@ -231,6 +232,42 @@ async def test_gguf_preflight_missing_llama_cpp_via_api(client, export_service, 
     assert response.status_code == 200
     data = response.json()
     assert data["ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_gguf_preflight_missing_convert_deps_via_api(app, client, data_dir):
+    """The dependency gate must reach the client, not just the service."""
+    settings = get_settings()
+    llama_dir = settings.cache_dir / "llama.cpp"
+    llama_dir.mkdir(parents=True, exist_ok=True)
+    (llama_dir / "convert_hf_to_gguf.py").write_text("# stub")
+    model_path = _make_model_dir(data_dir, "mlx-community/Foo", {"model_type": "llama"})
+    subprocess = RecordingSubprocess()
+    service = ExportService(
+        settings, run_subprocess=subprocess, module_available=lambda module: module != "torch"
+    )
+    app.dependency_overrides[get_export_service] = lambda: service
+    try:
+        preflight = await client.get(
+            "/api/v1/export/gguf/preflight", params={"model_path": str(model_path)}
+        )
+        start = await client.post(
+            "/api/v1/export/gguf",
+            json={"model_path": str(model_path), "outtype": "f16", "output_name": "out"},
+        )
+    finally:
+        app.dependency_overrides.pop(get_export_service, None)
+
+    assert preflight.status_code == 200
+    checks = {c["name"]: c for c in preflight.json()["checks"]}
+    assert preflight.json()["ok"] is False
+    assert checks["llama_cpp_available"]["ok"] is True
+    assert checks["convert_deps_importable"]["ok"] is False
+
+    assert start.status_code == 422
+    detail = start.json()["error"]["detail"]
+    assert [c["name"] for c in detail["checks"]] == ["convert_deps_importable"]
+    assert subprocess.calls == []
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_export_api.py
+++ b/backend/tests/integration/test_export_api.py
@@ -38,7 +38,12 @@ class RecordingSubprocess:
 @pytest_asyncio.fixture
 async def export_service(app, data_dir):
     subprocess = RecordingSubprocess()
-    service = ExportService(get_settings(), run_subprocess=subprocess)
+    # The preflight probes this interpreter for llama.cpp's converter deps,
+    # which the default backend environment does not install; pin the answer
+    # so these tests describe the API, not the machine they run on.
+    service = ExportService(
+        get_settings(), run_subprocess=subprocess, module_available=lambda module: True
+    )
     app.dependency_overrides[get_export_service] = lambda: service
     yield service, subprocess
     app.dependency_overrides.pop(get_export_service, None)
@@ -211,6 +216,7 @@ async def test_gguf_preflight_all_green_via_api(client, export_service, data_dir
     assert data["ok"] is True
     assert {c["name"] for c in data["checks"]} == {
         "llama_cpp_available",
+        "convert_deps_importable",
         "arch_supported",
         "weights_dequantized",
     }

--- a/backend/tests/unit/test_export_service.py
+++ b/backend/tests/unit/test_export_service.py
@@ -60,6 +60,18 @@ async def settings(tmp_path) -> Settings:
     return s
 
 
+@pytest.fixture(autouse=True)
+def convert_deps_installed(monkeypatch):
+    """Pretend llama.cpp's converter deps are importable.
+
+    The GGUF preflight probes *this* interpreter for `torch` & co., which the
+    default backend environment (and CI) deliberately does not install. Tests
+    about that check inject their own prober; the rest should not depend on
+    whether the machine running them happens to have torch.
+    """
+    monkeypatch.setattr("app.services.export_service._module_available", lambda module: True)
+
+
 @pytest.fixture
 async def conn(settings):
     async with aiosqlite.connect(settings.db_path) as c:
@@ -355,6 +367,92 @@ async def test_preflight_missing_config_fails_arch_and_weights(settings, tmp_pat
     by_name = {c.name: c for c in report.checks}
     assert by_name["arch_supported"].ok is False
     assert by_name["weights_dequantized"].ok is False
+
+
+@pytest.mark.asyncio
+async def test_preflight_missing_convert_deps_fails(settings):
+    """A findable script whose imports do not resolve must not read as ready."""
+    llama_dir = settings.cache_dir / "llama.cpp"
+    llama_dir.mkdir(parents=True, exist_ok=True)
+    (llama_dir / "convert_hf_to_gguf.py").write_text("# stub")
+    model_path = _make_model_dir(settings, "mlx-community/Foo", {"model_type": "llama"})
+
+    service = ExportService(
+        settings,
+        run_subprocess=RecordingSubprocess(),
+        module_available=lambda module: module != "torch",
+    )
+    report = await service.preflight_gguf(str(model_path))
+
+    assert report.ok is False
+    by_name = {c.name: c for c in report.checks}
+    assert by_name["llama_cpp_available"].ok is True
+    assert by_name["convert_deps_importable"].ok is False
+    assert "torch" in by_name["convert_deps_importable"].message
+    assert "uv sync --extra gguf" in by_name["convert_deps_importable"].message
+
+
+@pytest.mark.asyncio
+async def test_preflight_bundled_gguf_py_does_not_require_gguf_package(settings):
+    """A llama.cpp checkout ships gguf-py, so the published package is optional."""
+    llama_dir = settings.cache_dir / "llama.cpp"
+    (llama_dir / "gguf-py" / "gguf").mkdir(parents=True, exist_ok=True)
+    (llama_dir / "convert_hf_to_gguf.py").write_text("# stub")
+    model_path = _make_model_dir(settings, "mlx-community/Foo", {"model_type": "llama"})
+
+    service = ExportService(
+        settings,
+        run_subprocess=RecordingSubprocess(),
+        module_available=lambda module: module != "gguf",
+    )
+    report = await service.preflight_gguf(str(model_path))
+
+    assert report.ok is True
+    by_name = {c.name: c for c in report.checks}
+    assert by_name["convert_deps_importable"].ok is True
+
+
+@pytest.mark.asyncio
+async def test_preflight_bare_install_requires_gguf_package(settings):
+    """Homebrew's layout has no gguf-py, so `gguf` must come from the env."""
+    llama_dir = settings.cache_dir / "llama.cpp"
+    llama_dir.mkdir(parents=True, exist_ok=True)
+    (llama_dir / "convert_hf_to_gguf.py").write_text("# stub")
+    model_path = _make_model_dir(settings, "mlx-community/Foo", {"model_type": "llama"})
+
+    service = ExportService(
+        settings,
+        run_subprocess=RecordingSubprocess(),
+        module_available=lambda module: module != "gguf",
+    )
+    report = await service.preflight_gguf(str(model_path))
+
+    assert report.ok is False
+    by_name = {c.name: c for c in report.checks}
+    assert by_name["convert_deps_importable"].ok is False
+    assert "gguf" in by_name["convert_deps_importable"].message
+
+
+@pytest.mark.asyncio
+async def test_start_gguf_refuses_when_convert_deps_missing(settings, conn):
+    llama_dir = settings.cache_dir / "llama.cpp"
+    llama_dir.mkdir(parents=True, exist_ok=True)
+    (llama_dir / "convert_hf_to_gguf.py").write_text("# stub")
+    model_path = _make_model_dir(settings, "mlx-community/Foo", {"model_type": "llama"})
+    subprocess = RecordingSubprocess()
+
+    service = ExportService(
+        settings,
+        run_subprocess=subprocess,
+        module_available=lambda module: module != "torch",
+    )
+    with pytest.raises(ValidationAppError):
+        await service.start_gguf(
+            conn,
+            GGUFRequest(model_path=str(model_path), outtype="f16", output_name="out"),
+            BackgroundTasks(),
+        )
+    assert subprocess.calls == []
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_export_service.py
+++ b/backend/tests/unit/test_export_service.py
@@ -430,7 +430,9 @@ async def test_preflight_bare_install_requires_gguf_package(settings):
     assert report.ok is False
     by_name = {c.name: c for c in report.checks}
     assert by_name["convert_deps_importable"].ok is False
-    assert "gguf" in by_name["convert_deps_importable"].message
+    # Match the list of missing modules, not the `uv sync --extra gguf` hint
+    # that every failure message ends with.
+    assert "bulamıyor: gguf." in by_name["convert_deps_importable"].message
 
 
 @pytest.mark.asyncio

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -307,6 +307,83 @@ wheels = [
 ]
 
 [[package]]
+name = "cuda-bindings"
+version = "13.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/6b/457ca12dad3ee9bfcc9a545cfd6b64b359ba49de40f776f6e028e678f262/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5879712accf6e14bb01aa5e67440eb84998b8d104b509cc7a6dc0b8f656a474", size = 6053539, upload-time = "2026-05-29T23:11:43.19Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7a/c5e3c34a409b148f5c0f5a4ea374158f95d488862c1dffedf9aa5c639df9/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04436a9364059c84b8f9636f359eccda1cf814341f5b670c71d80d2f79dbc708", size = 6674166, upload-time = "2026-05-29T23:11:45.478Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e32d08f71ebcdf00f0f41eab2eb37e8da94c8ed411cc9f7f7a019ce6b34abe3a", size = 6657965, upload-time = "2026-05-29T23:11:52.227Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6e/2394f8163360f8391f8f1b7e72d300a82724edb81a7b7084c799fbd4c91f/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9efb21c1ee64981e184b9e0ba5eb3179e5ba3d4b51665a6cb52b8ef3d01a7cbf", size = 5920504, upload-time = "2026-05-29T23:11:56.883Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c2/ef9b6a63f7dc432712a462c816662e662e00d38caa9b861c8c2588195d03/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2732904099e0a4d4db774a5fc6d91ee95fae065b4d2ecabb4968c5fe2406c9d7", size = 6476660, upload-time = "2026-05-29T23:11:59.188Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/81/bff68ce829999c1e4209c761bbf903b1c06ec570416ddb25020864ad5907/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ab2f74ed65bfef4163ba07a8db16f1085e0729291db12a2423aff84ee8278b8", size = 6013639, upload-time = "2026-05-29T23:12:03.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e0/c8a1f0c8f9ffdea4f5fe6dbab89b326cef4d85caf489dad39e209da89416/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd4c814d311ec08c981f6dded1dbe7d4b371067ee4f6c14cccec4bde9590f80", size = 6534419, upload-time = "2026-05-29T23:12:05.633Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b8/83b1f563925b290f2d11a01a77a84013ba56052fe3653a5bef3ccfbb43d6/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c3c772dfff49681541d59630c90f858e173ac926b9c593a2b7123f2a1043cc76", size = 5809771, upload-time = "2026-05-29T23:12:10.422Z" },
+    { url = "https://files.pythonhosted.org/packages/12/20/e79b4bfe98f075195afb6343d41c498f9dbd2d161d7021d4d28bceb83581/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:36febb7c1079d68a981dbbd8d5a67235b399802b82075c9388624719607e52b9", size = 6358584, upload-time = "2026-05-29T23:12:12.767Z" },
+]
+
+[[package]]
+name = "cuda-pathfinder"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/b4/d088047afe39827556df21118cac9ffd20cc3f968c99a7681494d1eb333c/cuda_pathfinder-1.6.0-py3-none-any.whl", hash = "sha256:1503af579d8379c24bdd65528379bc57039b0455be9f5f9686cf8e473a1fce51", size = 54591, upload-time = "2026-07-21T15:03:56.224Z" },
+]
+
+[[package]]
+name = "cuda-toolkit"
+version = "13.0.3.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/c7/a79086a62c98befcdb8349656c6f114e2db3b8b2422f6e25c97a7f2a9a3c/cuda_toolkit-13.0.3.0-py2.py3-none-any.whl", hash = "sha256:d693caaa261214ddd7dbb60d68e71cbed884e68c2be7509778f3051da0b91c3f", size = 2512, upload-time = "2026-04-14T00:50:08.173Z" },
+]
+
+[package.optional-dependencies]
+cublas = [
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+cudart = [
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+cufft = [
+    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+cufile = [
+    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+cupti = [
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+curand = [
+    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+cusolver = [
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+cusparse = [
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+nvjitlink = [
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+nvrtc = [
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+nvtx = [
+    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+
+[[package]]
 name = "datasets"
 version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -483,6 +560,22 @@ wheels = [
 [package.optional-dependencies]
 http = [
     { name = "aiohttp" },
+]
+
+[[package]]
+name = "gguf"
+version = "0.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/ae/17f1308ae45cd7b08ebb521747d5b23f4efc4d172038a4e228dd5106c3ff/gguf-0.19.0.tar.gz", hash = "sha256:dbadcd6cc7ccd44256f2229fe7c2dff5e8aa5cf0612ab987fd2b1a57e428923f", size = 111220, upload-time = "2026-05-06T13:04:03.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/bb/d71d6da82763528c2c2ed6b59a9d6142c6595545a4c448e2085d155e88c2/gguf-0.19.0-py3-none-any.whl", hash = "sha256:70bcd10edfe697fb2dad6e40af2234b9d8ece9a41a99761405121ebda1c3c1cd", size = 118475, upload-time = "2026-05-06T13:04:02.588Z" },
 ]
 
 [[package]]
@@ -943,6 +1036,11 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+gguf = [
+    { name = "gguf" },
+    { name = "torch" },
+    { name = "transformers" },
+]
 mlx = [
     { name = "mlx-lm" },
     { name = "mlx-lm-lora" },
@@ -961,6 +1059,7 @@ requires-dist = [
     { name = "aiosqlite", specifier = ">=0.22,<1" },
     { name = "datasets", specifier = ">=5.0,<6" },
     { name = "fastapi", specifier = ">=0.139.2,<1" },
+    { name = "gguf", marker = "extra == 'gguf'", specifier = ">=0.19,<1" },
     { name = "huggingface-hub", specifier = ">=1.23,<2" },
     { name = "jinja2", specifier = ">=3.1,<4" },
     { name = "mlx-lm", marker = "extra == 'mlx'", specifier = "==0.31.3" },
@@ -972,9 +1071,11 @@ requires-dist = [
     { name = "python-docx", specifier = ">=1.2,<2" },
     { name = "python-multipart", specifier = ">=0.0.32,<1" },
     { name = "pyyaml", specifier = ">=6.0,<7" },
+    { name = "torch", marker = "extra == 'gguf'", specifier = ">=2.13,<3" },
+    { name = "transformers", marker = "extra == 'gguf'", specifier = ">=5.13,<6" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.51,<1" },
 ]
-provides-extras = ["mlx"]
+provides-extras = ["mlx", "gguf"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -992,6 +1093,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d6/ef/d74ae99cfe9ddb59fd08abd14f47754c3d199291a93756903fa595b31b8a/mlx_metal-0.32.0-py3-none-macosx_14_0_arm64.whl", hash = "sha256:5b64b20ac24b0c401f489de01e8209edc4d372125201f19314e6f39e385322aa", size = 40824649, upload-time = "2026-07-07T17:55:20.7Z" },
     { url = "https://files.pythonhosted.org/packages/d5/38/b96a3de98cfbb009592b3870af46ff63657b192f8d1e06c6c1faea5fbef3/mlx_metal-0.32.0-py3-none-macosx_15_0_arm64.whl", hash = "sha256:1bd94a1ce5b03a0c898771a3e759f0124300c6ab5155127906a1d50b1f3fcf19", size = 40818869, upload-time = "2026-07-07T17:55:25.059Z" },
     { url = "https://files.pythonhosted.org/packages/dc/59/65d32520175379df33f107749193aa94ea9db069167a36a1a100ff689f62/mlx_metal-0.32.0-py3-none-macosx_26_0_arm64.whl", hash = "sha256:3af76a498d84804f66119800499f9d143d7dffb0878a0dd0d7c2846e58565fd7", size = 56511379, upload-time = "2026-07-07T17:55:36.045Z" },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
 ]
 
 [[package]]
@@ -1129,6 +1239,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/74/d2c27e03cb84251dfe7249b8e82923643c6d48fa4883b9476b025e7dc7eb/multiprocess-0.70.19-py313-none-any.whl", hash = "sha256:8d5eb4ec5017ba2fab4e34a747c6d2c2b6fecfe9e7236e77988db91580ada952", size = 156414, upload-time = "2026-01-19T06:47:35.915Z" },
     { url = "https://files.pythonhosted.org/packages/a0/61/af9115673a5870fd885247e2f1b68c4f1197737da315b520a91c757a861a/multiprocess-0.70.19-py314-none-any.whl", hash = "sha256:e8cc7fbdff15c0613f0a1f1f8744bef961b0a164c0ca29bdff53e9d2d93c5e5f", size = 160318, upload-time = "2026-01-19T06:47:37.497Z" },
     { url = "https://files.pythonhosted.org/packages/7e/82/69e539c4c2027f1e1697e09aaa2449243085a0edf81ae2c6341e84d769b6/multiprocess-0.70.19-py39-none-any.whl", hash = "sha256:0d4b4397ed669d371c81dcd1ef33fd384a44d6c3de1bd0ca7ac06d837720d3c5", size = 133477, upload-time = "2026-01-19T06:47:38.619Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
 ]
 
 [[package]]
@@ -1272,6 +1391,158 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/94/a8/f98e50356cf167df656c526c2dfeec2d7dde182f2a3da4b458a5938e2776/numpy-2.5.1-cp314-cp314t-win32.whl", hash = "sha256:6eab239876581b2b3c5a242281b6007bbdbcd1c7085d7709bb57c5929b11e6bf", size = 6263298, upload-time = "2026-07-04T17:07:53.445Z" },
     { url = "https://files.pythonhosted.org/packages/72/ac/96ae880cdecad0b3275d9359fcec72667b49a4863c9f12942e43679dda02/numpy-2.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:83ce9c80d5b521b0d77ddcbe5447c218d247929b6cc056ca5351342accfff0af", size = 12748623, upload-time = "2026-07-04T17:07:55.384Z" },
     { url = "https://files.pythonhosted.org/packages/a1/5a/4d2b1601df3602dba7a14f3348ba9bfe94a18adb428e693df6154c293831/numpy-2.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:5a6db61f9aaa57e369905c67d852045d3c4f7126405b29d09b19dec118e9c9cb", size = 10697674, upload-time = "2026-07-04T17:07:58.506Z" },
+]
+
+[[package]]
+name = "nvidia-cublas"
+version = "13.1.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/cd/154ca20c38269e05eff77c1464e6c1da89f50a6390b565e9d82e06bc11e1/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:37936a16db8fe4ac1f065c2139360608a543a09275cb1a1af612e08cfa065436", size = 423138758, upload-time = "2026-04-08T18:46:58.655Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime"
+version = "13.0.96"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu13"
+version = "9.20.0.48"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304", size = 366173588, upload-time = "2026-03-09T19:29:34.474Z" },
+]
+
+[[package]]
+name = "nvidia-cufft"
+version = "12.0.0.61"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
+]
+
+[[package]]
+name = "nvidia-cufile"
+version = "1.15.1.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/70/4f193de89a48b71714e74602ee14d04e4019ad36a5a9f20c425776e72cd6/nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44", size = 1223672, upload-time = "2025-09-04T08:32:22.779Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/73/cc4a14c9813a8a0d509417cf5f4bdaba76e924d58beb9864f5a7baceefbf/nvidia_cufile-1.15.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bdc0deedc61f548bddf7733bdc216456c2fdb101d020e1ab4b88d232d5e2f6d1", size = 1136992, upload-time = "2025-09-04T08:32:14.119Z" },
+]
+
+[[package]]
+name = "nvidia-curand"
+version = "10.4.0.35"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver"
+version = "12.0.4.66"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse"
+version = "12.6.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu13"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/e1/cdc1797eadf82d3a9a575a19b33fdc871a97edbec42c00b5b5e914f4aff4/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f", size = 221051344, upload-time = "2025-09-05T18:49:51.289Z" },
+    { url = "https://files.pythonhosted.org/packages/34/7d/2661f2fb3ac4302f3a246f5fc030213ac60c1fe0bce84f9783dbd831dbb7/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0", size = 170148586, upload-time = "2025-09-05T18:50:50.248Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu13"
+version = "2.29.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/0d/daf50d44177ee0cbc7ff0a0c91eb5ff676c82be42f9a970bc7597f440c3a/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:674a12383e3c38a1bcccae7d4f3633b37852230b6047883cb2f4c2d1b36d9bf5", size = 206014712, upload-time = "2026-03-03T05:34:20.843Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f4/58e4e91b6919367c7aafb8e36fce9aad1a3047e536bf7e2fd560927d3a4c/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:edd81538446786ec3b73972543e53bb43bcaf0bfc8ef76cb679fcc390ffe136d", size = 205976000, upload-time = "2026-03-03T05:36:24.472Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink"
+version = "13.3.33"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/ee/580ca6f29dcab0221db8706badca1bbbb084f1975c4d4e83329c3a7e31f0/nvidia_nvjitlink-13.3.33-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:26a6de7fb4c8fdaa7703d3dad720d6d427ddfea5c48a528fd97c11733ad830e5", size = 40742423, upload-time = "2026-05-26T16:54:51.613Z" },
+    { url = "https://files.pythonhosted.org/packages/69/30/45414e35ff2eee7db3da037e5707037ccf9d2b5218ffbdb055ea4d5aa98a/nvidia_nvjitlink-13.3.33-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ce48b37dfeb3cb1eae4cf85adacb47d7a6539ea2272870c9a3628ce275c2037e", size = 39168635, upload-time = "2026-05-26T16:54:13.906Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu13"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/0f/05cc9c720236dcd2db9c1ab97fff629e96821be2e63103569da0c9b72f19/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dc2a197f38e5d0376ad52cd1a2a3617d3cdc150fd5966f4aee9bcebb1d68fe9", size = 60215947, upload-time = "2025-09-06T00:32:20.022Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/35/a9bf80a609e74e3b000fef598933235c908fcefcef9026042b8e6dfde2a9/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:290f0a2ee94c9f3687a02502f3b9299a9f9fe826e6d0287ee18482e78d495b80", size = 60412546, upload-time = "2025-09-06T00:32:41.564Z" },
+]
+
+[[package]]
+name = "nvidia-nvtx"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
 ]
 
 [[package]]
@@ -2058,6 +2329,15 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "83.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2089,6 +2369,18 @@ wheels = [
 ]
 
 [[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
 name = "tokenizers"
 version = "0.22.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2112,6 +2404,49 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
     { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
     { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-bindings", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "triton", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/fe/cba54dc58523434919b66f13a667e36e436deddd77ca519e96553617d4ec/torch-2.13.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:e76f9bcecc52b8ff711239a2f7547d5353df95878ab232f0773c1d95928b92f8", size = 111187938, upload-time = "2026-07-08T16:05:17.065Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/59/1e3160e18e12aa3038390efab3ce02b36a9d4d6a527ecdd8520dca2e68d8/torch-2.13.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:092790c696a760c729fd5722835f50b9d81fd7c8f141571f3f3cf4081a8f664c", size = 427199369, upload-time = "2026-07-08T16:04:51.054Z" },
+    { url = "https://files.pythonhosted.org/packages/01/79/1f2d34ad7034ee1c7ffc1cf8bf0f8213af2a81df6ecdb3997ecec107c09d/torch-2.13.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:60fcdcb2f3876e21146cb4524ef06397d727ca9ad5f020818547e25075fe3cb7", size = 526574961, upload-time = "2026-07-08T16:04:07.075Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fd/0f2ce40f58aefbdb3392f9acce3c8171940943ae2d661f70558bfa73befb/torch-2.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:a0d8b11f16a48d60e2015d8213aa0390744cbebb98e58b62b3514dddc656e330", size = 122015870, upload-time = "2026-07-08T16:05:27.59Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/3a/ed0f4d4d1dcde03bced7aac9a28e800abcdc0cbd06b6775044c9fbd877b7/torch-2.13.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2fe228aba290d14b9f31b049be550dbd469c3fd3013d7a19705b30454da97027", size = 111213045, upload-time = "2026-07-08T16:05:22.997Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a9/f6a2a4d763ff1df02e9a64c477029db614295bc9367f4131223791ccc243/torch-2.13.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:572df8be8ffb4599c88cbd6a0726f1f854f4da65d2e3c09f0e2c2283333cd6d4", size = 427210998, upload-time = "2026-07-08T16:04:37.708Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/82/fea946351658e6534db52d2cc12bc53087cbf87f9440c5f180f367c1950b/torch-2.13.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:796633c4cdf0fe2cdced72d8f88f22e73dbcfce83132763162f6d4bff13b820b", size = 526605292, upload-time = "2026-07-08T16:04:22.81Z" },
+    { url = "https://files.pythonhosted.org/packages/21/d6/e8f3c6f7e01f626f77259de9860d2a78bc84c40539e28e79b7e98b0bb659/torch-2.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:024c6cc0c1b085f2f91f20a3dc27b0471d021c31ce84b81be3afdc39f791fd9d", size = 122057313, upload-time = "2026-07-08T16:03:53.43Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fa/c1c10b7aff4a9a3e8956d4f0a5f468fa6db7abc3208805719076772b4833/torch-2.13.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:33449899ce5496c1b84b4853179d94fd102028ae1407314d9fb956bb79e70d09", size = 111213743, upload-time = "2026-07-08T16:03:28.579Z" },
+    { url = "https://files.pythonhosted.org/packages/11/18/9ecb37b56293a0be8d80f810bf672a72fe7e02f8b475d5ef1b9bf8a0d748/torch-2.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:1e09d6a722504957c694faceca843acde562786df1144ebcc5a74075ec7f6005", size = 427213008, upload-time = "2026-07-08T16:03:44.106Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/5a/7c50ba1b7b713d71d34669c6d13dab0a11531a3eceb0307a5162dbfec0f7/torch-2.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:a3a9a21312872af8a26950b2c15680335a386a1f56ed03e780653d78b9607e9e", size = 526602329, upload-time = "2026-07-08T16:03:12.649Z" },
+    { url = "https://files.pythonhosted.org/packages/91/3d/e7adcc6aaf36961cd18f56cf8ad0f3058c3a5c84ccf391762176c94581b8/torch-2.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:49b58f1e2c52440abb6f17c28f0335fe6c6d01ad1a7f55b0183b81e4b34d64e6", size = 122057920, upload-time = "2026-07-08T16:03:01.808Z" },
+    { url = "https://files.pythonhosted.org/packages/36/76/6dcc7f0c07052102dd36f83cbc5800842a909c8c3fbf1a7f8a5844954de9/torch-2.13.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d849b390e07d8d333ce8ecaf91b273c656c598379a19c9acf1318a883f6b391c", size = 111227066, upload-time = "2026-07-08T16:03:33.6Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/09/2c10e8cd0e00fa5d23c052df6ce467eaa7182399f5e0f824f1e4ff42ccae/torch-2.13.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:a3893dc2da0a972a8ca5d698c85a9f967559ac5f8ee1797b77408aa8734d073c", size = 427226309, upload-time = "2026-07-08T16:02:53.127Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c6/22c2102bbef14ca6a6cb4c20e42f088e49c5f812be4e160ae57502e325f9/torch-2.13.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:49f1ea385c754e54919408a9bb3b5a72b0b755bbe2c916c1d6f70afbec4908a2", size = 526614507, upload-time = "2026-07-08T16:02:16.441Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0c/7d1deb6bce5bc3e6042caf39100ac768eba3b9a098e1dddd16f75bd6489b/torch-2.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:4f8573e3ce9ebcd53fe922f01077a6085ccdfbe5f12fd215883a9d87d7a744fd", size = 122051871, upload-time = "2026-07-08T16:03:23.521Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ce/aa8b7f9949d32e0f2f624f342bc3b48112c1b8a130288465938bc83bcbf9/torch-2.13.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:c28def70706c2f9ecc752574766e8ae4da9b810ab6676b611166761a78a9f1e1", size = 111537025, upload-time = "2026-07-08T16:02:44.28Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d1/491e3a0389430946145888b0203f2b6a759ce2a61481b96a85c2da4f2ced/torch-2.13.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:31061ff56ed8fbf26c749806905aeb749ebeb819810fd5d52508aa5afd90dddc", size = 427219769, upload-time = "2026-07-08T16:02:31.18Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/1d/38006e045bf0a1fc28ef01e757c554e59e59a8770c284bc4f47b14e60441/torch-2.13.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:cc26eead4cf51d0b544e31e364dcf000846549c273bd148936fe9d24d29acb92", size = 526571320, upload-time = "2026-07-08T16:01:59.348Z" },
+    { url = "https://files.pythonhosted.org/packages/56/94/655c91992a882bd5071aa0b5d22a07dbb130d801e872be97c0b627a7c693/torch-2.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a7de8a313090dc5c7d7ba4bfe5c3be222528f9a4dba1acc83bddb1157360c4b8", size = 122306773, upload-time = "2026-07-08T16:02:39.832Z" },
 ]
 
 [[package]]
@@ -2145,6 +2480,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6e/f7/418169401560cec2b61512e6bf37b0cfb4c8e27700cfa868a1de073cb65d/transformers-5.13.1.tar.gz", hash = "sha256:1e2452d6778a7482158df5d5dacf6bf775d5b2fdcfce33caaf7f6b0e5f3e3397", size = 9196891, upload-time = "2026-07-11T09:15:50.845Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/29/47/54eacf96b5c835bbd6ca631aa2740e7705ed63d9e3a8afd2d2cc6d09cae5/transformers-5.13.1-py3-none-any.whl", hash = "sha256:53f0ea8aa397e29244c2377ba981bcaf0c87adcf44fbdd447ef6306522afcacd", size = 11503977, upload-time = "2026-07-11T09:15:46.801Z" },
+]
+
+[[package]]
+name = "triton"
+version = "3.7.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/f9/19d842d06a08559534fa1eaab6ca551b1bcf40f06620bddec1babaa2772d/triton-3.7.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4a0e1cd4c4a76370ed74a8432a53cea28716827d19e40ffc732233e35ceb3f6", size = 184664887, upload-time = "2026-06-17T20:03:42.913Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/5e/fce69606f7f240297f163e25539906732b199530d486ce67ae319877e821/triton-3.7.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6744957e9fd610a29680ec2346057d0c86948ed3812468670719f391e94b44a5", size = 197701306, upload-time = "2026-06-17T19:53:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/94/fa/f856e24deb462d5f18bd4b5a746957862ab9b6ee5834bda60605ec348366/triton-3.7.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9497f2e696ee368862a181a90b2dcc03ca978cc4f602abd67c7d81022a6988e1", size = 184692359, upload-time = "2026-06-17T20:03:48.288Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/6f/fb96d15db6f36d6eae4cafb998c2e0353bf59d7c4ea1662d7497f269134a/triton-3.7.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e40869937a68206ec70d7f25bb7ec6433cb083f9135e1f36dbd318dc449a728", size = 197719725, upload-time = "2026-06-17T19:53:20.419Z" },
+    { url = "https://files.pythonhosted.org/packages/00/42/c5089d4d9327fcd1e862c599cc2927f39418f84dd11a84cb2ccff9d4787a/triton-3.7.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cdbfc09d9ec58bc5e68321525653220de7515c199e7a8097a97c85e62b52cd0a", size = 184694629, upload-time = "2026-06-17T20:03:53.444Z" },
+    { url = "https://files.pythonhosted.org/packages/07/42/2c3ac59253ae8892b6f307875263dd23dc875cdf732d3aea40d6d41fb7cb/triton-3.7.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:58c0e131da05134a2a4788ccbcc0c1105cf0f54c8e98f19e34cd465396dc15eb", size = 197729241, upload-time = "2026-06-17T19:53:27.801Z" },
+    { url = "https://files.pythonhosted.org/packages/40/71/e01aa7ad573883ed9456f130226babdec70b005e098c4d6226a6238e761b/triton-3.7.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fe4ea396a06171f1f1f58cbd39c70b09294398f7dd7c620939bab54ad6f934fa", size = 184705764, upload-time = "2026-06-17T20:03:59.064Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/09/5683146fda6a2b569deb78ccfd8fbfea8bfe55f726b081c0a6bb18dd6f28/triton-3.7.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2020153b08280415ec0da6607834e79166442147e78e144df06b508c75b186d2", size = 197729537, upload-time = "2026-06-17T19:53:35.516Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f8/448220c3092019f9fdfab39ec47985968181d67da34b44f6a7f6280a5cbb/triton-3.7.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c58e4c61f0c73b5dba3b5d19b4a7093c32f90dc18b2a7f121a7c16ccd31107b7", size = 184814760, upload-time = "2026-06-17T20:04:04.984Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ac/229b7d4589d2e5937310e72c6d46e89599d16a4a12b479ffa1499fee8eb8/triton-3.7.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10ba85fa2cca4a2fbdeb36bf1cb082f2c252bda55bf9fccd74f65ec5bc647e68", size = 197824404, upload-time = "2026-06-17T19:53:42.772Z" },
 ]
 
 [[package]]

--- a/docs/api.md
+++ b/docs/api.md
@@ -346,6 +346,7 @@ separators (`/`, `\`) or `..`; must not start with `.` or `-`. Anything else →
 ```json
 {"ok": false, "checks": [
   {"name": "llama_cpp_available", "ok": true, "message": "..."},
+  {"name": "convert_deps_importable", "ok": true, "message": "..."},
   {"name": "arch_supported", "ok": true, "message": "llama"},
   {"name": "weights_dequantized", "ok": false, "message": "weights are 4-bit quantized; re-fuse with de_quantize=true"}
 ]}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -190,9 +190,14 @@ conversion can never take the API server down with it:
    --adapter-path ... --save-path ...` (optionally `--dequantize`) as a
    background subprocess. Blocked with `training_active` while any run is
    queued/running.
-2. **GGUF preflight** (`GET /export/gguf/preflight`) — three gate checks before
+2. **GGUF preflight** (`GET /export/gguf/preflight`) — four gate checks before
    allowing conversion: `llama_cpp_available` (a `convert_hf_to_gguf.py` file
    found in `MLXLF_LLAMA_CPP_DIR` or `<data_dir>/cache/llama.cpp`),
+   `convert_deps_importable` (the third-party modules that script imports at
+   module level — `torch`, `transformers`, `numpy`, plus `gguf` unless the
+   checkout ships its own `gguf-py` — resolve in `sys.executable`, the same
+   interpreter step 3 hands the script to; a bare `llama.cpp` install such as
+   Homebrew's satisfies the first check but still dies on `import torch`),
    `arch_supported` (the fused model's `config.json` `model_type` is in a
    curated allow-list: `llama`, `qwen2`, `qwen3`, `mistral`, `gemma`, `gemma2`,
    `phi3`), and `weights_dequantized` (no `"quantization"` key in

--- a/frontend/src/components/export/GGUFWizard.test.tsx
+++ b/frontend/src/components/export/GGUFWizard.test.tsx
@@ -47,6 +47,7 @@ describe('GGUFWizard', () => {
           ok: false,
           checks: [
             { name: 'llama_cpp_available', ok: true, message: 'llama.cpp found' },
+            { name: 'convert_deps_importable', ok: true, message: 'converter deps ready' },
             { name: 'arch_supported', ok: true, message: 'llama' },
             {
               name: 'weights_dequantized',
@@ -67,6 +68,39 @@ describe('GGUFWizard', () => {
 
     expect(
       await screen.findByText('weights are 4-bit quantized; re-fuse with de_quantize=true'),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Convert' })).toBeDisabled()
+  })
+
+  it('renders the convert-deps failure message and blocks submit', async () => {
+    server.use(...exportHandlers)
+    server.use(
+      http.get('/api/v1/export/gguf/preflight', () =>
+        HttpResponse.json({
+          ok: false,
+          checks: [
+            { name: 'llama_cpp_available', ok: true, message: 'llama.cpp found' },
+            {
+              name: 'convert_deps_importable',
+              ok: false,
+              message: 'convert_hf_to_gguf.py cannot import: torch',
+            },
+            { name: 'arch_supported', ok: true, message: 'llama' },
+            { name: 'weights_dequantized', ok: true, message: 'weights are f16' },
+          ],
+        }),
+      ),
+    )
+
+    const user = userEvent.setup()
+    renderWizard()
+
+    await screen.findByRole('option', { name: '/abs/exports/my-model-fused' })
+    await user.selectOptions(sourceSelect(), '/abs/exports/my-model-fused')
+    await user.type(screen.getByPlaceholderText('my-model'), 'my-gguf')
+
+    expect(
+      await screen.findByText('convert_hf_to_gguf.py cannot import: torch'),
     ).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Convert' })).toBeDisabled()
   })

--- a/frontend/src/test/handlers/export.ts
+++ b/frontend/src/test/handlers/export.ts
@@ -50,6 +50,7 @@ export const exportHandlers = [
       ok: true,
       checks: [
         { name: 'llama_cpp_available', ok: true, message: 'llama.cpp found' },
+        { name: 'convert_deps_importable', ok: true, message: 'converter deps ready' },
         { name: 'arch_supported', ok: true, message: 'llama' },
         { name: 'weights_dequantized', ok: true, message: 'weights are f16' },
       ],


### PR DESCRIPTION
## Sorun

GGUF export'ta preflight tüm kontrolleri yeşil verirken dönüşüm işi patlıyordu:

```
File "/opt/homebrew/bin/convert_hf_to_gguf.py", line 23, in <module>
    import torch
ModuleNotFoundError: No module named 'torch'
```

`start_gguf`, llama.cpp'nin `convert_hf_to_gguf.py` betiğini `sys.executable`
ile — yani backend'in kendi venv'i ile — çalıştırıyor. Betiği diskte bulmak,
o betiğin kendi import bloğunu geçebileceğini kanıtlamıyor: `torch` ne
`backend/pyproject.toml`'da tanımlıydı ne de gerekliliği belgeliydi. Sonuç,
export akışının üretebileceği en kötü çıktı — yeşil preflight, ardından
başarısız iş.

Bu, belgelenmiş kurulumda GGUF export'un hiç çalışmadığı anlamına geliyordu;
Homebrew'un llama.cpp'si ilk kontrolü geçtiği için sorun preflight'a hiç
yansımıyordu.

## Değişiklik

Sözleşme-önce, üç commit:

1. **`docs/api.md` + `architecture.md` + README** — dördüncü preflight
   kontrolü `convert_deps_importable` sözleşmeye donduruldu, `gguf` extra'sı
   ve GGUF export önkoşulları belgelendi.
2. **Uygulama** — kontrol, betiğin modül seviyesinde import ettiği modülleri
   (`torch`, `transformers`, `numpy`) *bu* yorumlayıcıda arıyor. `gguf`
   paketini yalnızca llama.cpp dizini kendi `gguf-py`'sini taşımıyorsa
   istiyor (checkout taşır, Homebrew kurulumu taşımaz — betik satır 28-30'da
   o dizini kendisi `sys.path`'e ekliyor). `POST /export/gguf` preflight'ı
   sunucu tarafında yeniden koştuğu için eksik bağımlılık artık başarısız bir
   arka plan işi değil, eyleme dönüştürülebilir mesajlı bir `422`.
   Modüller yeni opsiyonel `gguf` extra'sından geliyor — opsiyonel, çünkü
   torch uygulamanın başka hiçbir yerinin ihtiyaç duymadığı büyük bir indirme.
3. **Test sıkılaştırma** — bağımsız bir doğrulama turunun bulduğu üç zayıf
   assertion (vacuous `"gguf" in message`, sırasız `set` karşılaştırması,
   API seviyesinde eksik 422 kapsaması).

## Doğrulama

Gerçek MLX runtime'ı ve gerçek modelle:

```
MLXLF_E2E_GGUF=1 MLXLF_LLAMA_CPP_DIR=/opt/homebrew/bin make e2e
→ preflight 4/4 yeşil, ✅ E2E SMOKE TEST PASSED in 22.4s, 258 MB .gguf
```

Aynı komut bu değişiklik olmadan 9. adımda `ModuleNotFoundError` ile
düşüyordu.

| Kontrol | Sonuç |
|---|---|
| `backend pytest` | 502 passed |
| `ruff check . ../e2e` | temiz |
| `vitest` | 273 passed / 53 dosya |
| `tsc --noEmit`, `oxlint` | temiz |
| `make e2e` (SFT) | PASSED |
| `make e2e-faz2` (DPO+recipes+arena+history) | PASSED |

CI etkisi yok: `ci.yml` sade `uv sync` kullanıyor (extra yok) ve testler
enjekte edilen bir prober ile koştuğu için torch olmayan Linux runner'da da
geçiyor. `uv.lock` diffinde silinen tek satır `provides-extras`; mevcut hiçbir
paket sürümü değişmedi.

## Bilinerek kapsam dışı bırakılanlar

- `find_spec`, `sys.path`'te çıplak bir `gguf/` dizini varsa namespace paketi
  olarak yanlış yeşil verebilir; `NO_LOCAL_GGUF=1` set edilmişse `gguf-py`
  istisnası hatalı çalışır. İkisi de gerçekçi değil ve kapatmak probe'u
  subprocess'e taşımayı gerektirir — preflight her `modelPath` değişiminde
  çağrıldığı için (debounce yok) kabul edilemez maliyet.
- `docs/api.md` hâlâ `POST /export/gguf` için `422`'yi belgelemiyor. Bu
  önceden var olan bir boşluk; aynı gate `main`'de de mevcuttu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)