### PR TITLE
test: stop two cancel tests from measuring machine load

### DIFF
--- a/backend/tests/integration/test_training_api.py
+++ b/backend/tests/integration/test_training_api.py
@@ -58,6 +58,31 @@ async def training_client(training_app):
         yield ac
 
 
+@pytest.fixture
+async def application_and_slow_manager(training_app):
+    """Like `training_client`, but with a worker that cannot finish on its own.
+
+    For tests that must act on a job while it is still running: the default
+    fake worker does 3 steps with no delay, so anything racing it is decided
+    by the scheduler.
+    """
+    application, _ = training_app
+    slow_manager = manager_module.JobManager(
+        settings=get_settings(),
+        worker_argv_factory=make_worker_argv_factory(
+            "happy", FAKE_WORKER_ITERS=100_000, FAKE_WORKER_STEP_DELAY=0.01
+        ),
+        cancel_grace_seconds=0.3,
+    )
+    application.dependency_overrides[manager_module.get_job_manager] = lambda: slow_manager
+    transport = ASGITransport(app=application)
+    try:
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield application, slow_manager, ac
+    finally:
+        await slow_manager.shutdown()
+
+
 @pytest.mark.asyncio
 async def test_create_job_returns_201_running(training_client):
     resp = await training_client.post("/api/v1/train/jobs", json=_config_payload())
@@ -141,19 +166,27 @@ async def test_run_lifecycle_detail_list_metrics_logs(training_app, training_cli
 
 
 @pytest.mark.asyncio
-async def test_cancel_returns_202_and_eventually_cancelled(training_app, training_client):
-    _application, test_manager = training_app
+async def test_cancel_returns_202_and_eventually_cancelled(application_and_slow_manager):
+    # `iters` in the payload does not reach the fake worker — it reads
+    # FAKE_WORKER_ITERS — so the shared fixture's 3 zero-delay steps finish in
+    # microseconds and whether the cancel lands first is a coin toss. It lost
+    # on a busy machine and the run came back `completed`. This manager's
+    # worker is still on step 1 of 100000 when the cancel arrives.
+    _application, slow_manager, client = application_and_slow_manager
 
-    created = await training_client.post("/api/v1/train/jobs", json=_config_payload(iters=1000))
+    created = await client.post("/api/v1/train/jobs", json=_config_payload())
     run_id = created.json()["run_id"]
+    # Pin the premise: 100000 steps at 10ms cannot already be done, so what
+    # follows really does cancel a running job.
+    assert not slow_manager.done_event(run_id).is_set()
 
-    cancel_resp = await training_client.post(f"/api/v1/train/jobs/{run_id}/cancel")
+    cancel_resp = await client.post(f"/api/v1/train/jobs/{run_id}/cancel")
     assert cancel_resp.status_code == 202
     assert cancel_resp.json()["run_id"] == run_id
 
-    await asyncio.wait_for(test_manager.done_event(run_id).wait(), timeout=5)
+    await asyncio.wait_for(slow_manager.done_event(run_id).wait(), timeout=10)
 
-    final = await training_client.get(f"/api/v1/train/jobs/{run_id}")
+    final = await client.get(f"/api/v1/train/jobs/{run_id}")
     assert final.json()["status"] == "cancelled"
 
 

--- a/backend/tests/unit/test_inference_service.py
+++ b/backend/tests/unit/test_inference_service.py
@@ -164,8 +164,14 @@ class TestStreamChat:
 
         assert out_frames[-1]["type"] == "done"
         token_frames = [f for f in out_frames if f["type"] == "token"]
-        # Cancellation cuts the (otherwise infinite) stream short.
-        assert 0 < len(token_frames) < 1000
+        # The fake generator never ends, so terminating at all is the proof
+        # that cancellation cut the stream short — and `asyncio.wait_for`
+        # above already enforces that. How many tokens slip through between
+        # `cancel_event.set()` and the service's next check is pure
+        # scheduling, so an upper bound here measures machine load, not
+        # behaviour: it read 1261 and 2114 on a busy machine against a
+        # hand-picked limit of 1000.
+        assert len(token_frames) > 0
         usage = out_frames[-1]["usage"]
         assert usage["prompt_tokens"] == 7
         assert usage["completion_tokens"] >= 1


### PR DESCRIPTION
## Sorun

İki test, test ettikleri davranış yerine makinenin ne kadar yüklü olduğunu ölçüyor. Suite'i paralel ikinci bir suite ile birlikte 20 kez koşarken **4 başarısızlık** verdiler; kod tarafında hiçbir kusur yok.

### 1. `test_cancel_mid_stream_stops_and_yields_partial_done`

```
AssertionError: assert 1261 < 1000     (run 8, 11)
AssertionError: assert 2114 < 1000     (run 15)
```

`assert 0 < len(token_frames) < 1000` — üst sınır bir zamanlama varsayımı. İptal edilen `fake_stream_generate` **sonsuz** üretiyor, dolayısıyla akışın hiç bitmesi iptalin çalıştığının kanıtı ve onu zaten üstteki `asyncio.wait_for(..., timeout=5)` sağlıyor. Token sayısı ise yalnızca `cancel_event.set()` ile servisin bir sonraki kontrolü arasında üretici thread'in ne kadar ilerlediği — 1000 sabiti bunun için elle seçilmiş bir tahmin.

### 2. `test_cancel_returns_202_and_eventually_cancelled`

```
AssertionError: assert 'completed' == 'cancelled'     (run 16)
```

Bu daha sinsi. Test payload'da `iters=1000` gönderiyor, uzun bir iş kuruyormuş gibi görünüyor — ama bu değer fake worker'a **hiç ulaşmıyor**: o `FAKE_WORKER_ITERS`'i okuyor ve paylaşılan `training_app` fixture'ı onu `FAKE_WORKER_STEP_DELAY=0.0` ile 3'e sabitliyor. Yani iş mikrosaniyelerde bitiyor ve iptalin ona yetişip yetişmemesi saf yarış. Yükte yarışı kaybetti ve koşum `completed` döndü.

Asıl kusur yarışın kendisi değil, testin kurulumu hakkında yanlış şey söylemesi: `iters=1000` satırı bir yıl sonra okuyan birini de yanıltırdı.

## Değişiklik

- Birincide üst sınır kaldırıldı; `len(token_frames) > 0` kaldı ve yorumda sonlanmanın neden yeterli kanıt olduğu ile gözlenen 1261/2114 değerleri yazılı.
- İkincisi için `application_and_slow_manager` fixture'ı eklendi: 100000 adım × 10 ms'lik bir worker, yani iptal geldiğinde iş kesinlikle 1. adımda. Test artık `iters` payload'ına güvenmiyor ve **önkoşulu baştan assert ediyor** (`assert not slow_manager.done_event(run_id).is_set()`) — varsayım kontrol ediliyor. Fixture kendi manager'ını `finally` içinde `shutdown()` ediyor, arkada süreç bırakmıyor.

## Doğrulama

Düzeltmenin tek anlamlı kanıtı aynı yük altında koşmak: boşta makinede bu testler zaten geçiyordu.

| | Yük altında 20 koşum | Başarısızlık |
|---|---|---|
| Öncesi | 18-40s/koşum | **4** (3× inference, 1× training) |
| Sonrası | 18.8-38.3s/koşum | **0** |

Yük, paralel koşan ikinci bir test suite'i ile üretildi; referans olarak boşta bir koşum 13s sürüyor, buradaki koşumlar 18.8-38.3s — yani çekişme gerçekten vardı.

Tek koşum: `502 passed`, `ruff check . ../e2e` temiz.

## Kapsam dışı — hâlâ açık

Bu PR **tüm** flake'leri kapatmıyor:

- `PytestUnhandledThreadExceptionWarning: Exception in thread Thread-N (_connection_worker_thread)` uyarısı hâlâ ara ara çıkıyor (bu doğrulama koşumunun 10. turunda `2 warnings` olarak göründü). Test başarısızlığı değil, düzelttiğim iki testle de ilgisi yok — ayrı bir konu.
- Frontend suite'inde bir kez tek testlik bir başarısızlık gözlendi (test adı çıktıda kırpılmıştı). 40 koşumda (`--silent` dahil, 20+20) tekrar üretemedim, o yüzden burada bir iddiada bulunmuyorum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)