### PR TITLE
fix(ui): cap modal height and scroll its body

### DIFF
--- a/frontend/src/components/common/Modal.test.tsx
+++ b/frontend/src/components/common/Modal.test.tsx
@@ -54,4 +54,27 @@ describe('Modal', () => {
     await user.click(backdrop as Element)
     expect(onClose).toHaveBeenCalledTimes(1)
   })
+
+  // jsdom does no layout, so this pins the structure that makes tall content
+  // scrollable rather than the resulting geometry: the body scrolls, and the
+  // footer sits outside it so its buttons cannot be scrolled out of reach.
+  // The geometry itself is checked against a real browser.
+  it('keeps the footer outside the scrollable body', () => {
+    const { container } = render(
+      <Modal open={true} onClose={() => {}} title="Tall" footer={<button>Import</button>}>
+        <p>content</p>
+      </Modal>,
+    )
+
+    const dialog = screen.getByRole('dialog')
+    const body = container.querySelector('[data-modal-body]')
+    expect(body).not.toBeNull()
+    expect(body?.className).toContain('overflow-y-auto')
+    expect(body?.className).toContain('min-h-0')
+    expect(dialog.className).toContain('max-h-')
+
+    const importButton = screen.getByRole('button', { name: 'Import' })
+    expect(body?.contains(importButton)).toBe(false)
+    expect(dialog.contains(importButton)).toBe(true)
+  })
 })

--- a/frontend/src/components/common/Modal.tsx
+++ b/frontend/src/components/common/Modal.tsx
@@ -28,20 +28,29 @@ export function Modal({ open, onClose, title, children, footer }: ModalProps) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
       <div className="absolute inset-0 bg-black/60" onClick={onClose} aria-hidden="true" />
+      {/* Capped to the viewport and laid out as a column: the header and
+          footer keep their size while the body takes the rest and scrolls.
+          Without the cap a dialog taller than the window grows past it in
+          both directions — it is centred — so the footer's buttons become
+          unreachable with nothing to scroll. `min-h-0` is what lets the body
+          shrink below its content height; a flex child refuses to by
+          default, and overflow never kicks in. */}
       <div
         role="dialog"
         aria-modal="true"
         aria-label={title}
-        className="relative z-10 w-full max-w-md rounded-xl border border-border bg-surface p-5 shadow-xl"
+        className="relative z-10 flex max-h-[calc(100vh-2rem)] w-full max-w-md flex-col rounded-xl border border-border bg-surface p-5 shadow-xl"
       >
-        <div className="mb-4 flex items-center justify-between">
+        <div className="mb-4 flex shrink-0 items-center justify-between">
           {title && <h2 className="text-base font-semibold text-text">{title}</h2>}
           <IconButton aria-label={t('actions.close')} variant="ghost" onClick={onClose} className="ml-auto">
             <CloseIcon />
           </IconButton>
         </div>
-        <div className="text-sm text-text">{children}</div>
-        {footer && <div className="mt-5 flex justify-end gap-2">{footer}</div>}
+        <div data-modal-body className="min-h-0 flex-1 overflow-y-auto text-sm text-text">
+          {children}
+        </div>
+        {footer && <div className="mt-5 flex shrink-0 justify-end gap-2">{footer}</div>}
       </div>
     </div>
   )


### PR DESCRIPTION
## Sorun

Dataset import dialog'unda "Split automatically after import" açıkken — ki anahtarın **varsayılan hali bu** (`useState(true)`) — Import tuşuna ulaşılamıyor.

Kullanıcı bildirdi, Chromium'da tekrar üretip ölçtüm (720px viewport, gerçek uygulama):

| auto-split | Import tuşu `y` | Viewport içinde |
|---|---|---|
| **ON** (varsayılan) | 753 | ❌ |
| OFF | 611 | ✅ |

Kaydırma da bir çıkış yolu değil: `scrollable_containers=[]`, `body_scrolls=false`. Tuşa erişmenin **hiçbir** yolu yoktu.

## Kök neden

`Modal.tsx`'te. Dış sarmalayıcı `flex items-center justify-center` ile dialog'u ortalıyor, ama ne sarmalayıcıda ne dialog'da yükseklik sınırı veya taşma yönetimi var. İçerik pencereden uzun olunca dialog dışına doğru büyüyor ve **ortalandığı için taşma iki yöne** gidiyor: başlık üstten, footer alttan çıkıyor. Kaydırılacak bir kapsayıcı olmadığı için ikisi de kaybediliyor.

Bu, `ImportDatasetDialog`'a özgü değil — **uygulamadaki her modal** aynı kusuru paylaşıyor. Diğerleri (ConfirmDialog vb.) yalnızca eşiği aşmayacak kadar kısa olduğu için görünmüyordu.

Dürüstlük notu: eksik yükseklik sınırı baştan vardı, ama #71'de eklediğim "Target format" alanı + üç satırlık yardım metni dialog'u ~90px uzatarak eşiği aştırdı.

## Değişiklik

Dialog artık viewport'a sınırlanmış bir flex kolon: header ve footer sabit boyutta, gövde aradaki alanı alıp kaydırıyor.

```
max-h-[calc(100vh-2rem)] + flex flex-col
  header  → shrink-0
  body    → min-h-0 flex-1 overflow-y-auto
  footer  → shrink-0
```

`min-h-0` kritik: flex çocuğu varsayılan olarak içeriğinin altına küçülmeyi reddeder ve taşma hiç devreye girmez. `2rem`, sarmalayıcının `p-4`'ünün iki yanı.

## Doğrulama

Gerçek Chromium, çalışan uygulama, auto-split açık:

| Viewport | Import `y` (öncesi → sonrası) | Viewport içinde | Gövde kaydırma |
|---|---|---|---|
| 720 | 753 → 651 | ❌ → ✅ | 746px → 542px alan |
| 600 | — → 531 | ✅ | 746px → 422px |
| 500 | — → 431 | ✅ | 746px → 322px |

Kullanıcı da düzeltilmiş uygulamada elle test edip onayladı.

`tsc --noEmit` temiz, `vitest` 278 test geçiyor, `oxlint` çıkış 0 (yeni uyarı yok).

## Testin sınırı

Eklenen vitest testi **yapıyı** pinliyor — gövde `overflow-y-auto` + `min-h-0` taşıyor ve footer gövdenin dışında, yani düğmeler kaydırılıp erişilemez hale getirilemiyor. Geometriyi ölçmüyor, çünkü jsdom düzen hesaplamaz; geometri kanıtı yukarıdaki tarayıcı ölçümleri. Bu sınır testin yorumunda da yazılı.

🤖 Generated with [Claude Code](https://claude.com/claude-code)