### PR TITLE
Run comparison in History + changelog catch-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,31 @@ The version's source of truth is `backend/pyproject.toml` (reported by
 - Full UI internationalization: English and Turkish across every surface
   (~610 keys), with a persistent EN/TR switcher in the top bar and
   browser-language detection on first visit (#55)
+- HF import column mapping: `column_map` renames source columns onto the
+  canonical keys the format detector expects, so a dataset carrying the right
+  data under the wrong names imports as the right format (#71)
 - Dispatchable release workflow: one action validates the changelog/version
   coherence, tags main and publishes the GitHub release (#54)
 - Animated UI demo at the top of the README (#53)
+
+### Fixed
+
+- GGUF preflight now gates on the converter's own imports, so conversion fails
+  up front with a named missing dependency instead of mid-run (#69)
+- Dataset import says *why* format detection failed, not just that it did (#71)
+- Tall modals cap their height and scroll their body instead of overflowing the
+  viewport (#73)
+- Two cancel tests no longer measure machine load, which made them flaky on
+  busy runners (#72)
+
+### Changed
+
+- Dependency bumps: huggingface-hub, @tanstack/react-query, @vitejs/plugin-react,
+  oxlint, @tailwindcss/vite, react 19.2.8, setup-python 7, fastapi 0.139.2
+  (#57–#65, #76)
+- Dependabot groups updates per ecosystem so lockfile rewrites stop conflicting
+  with each other, and ruff is capped at the next minor — a linter minor ships
+  new rules, which breaks `make lint` like a breaking release would (#66)
 
 ## [0.2.0] - 2026-07-23
 


### PR DESCRIPTION
Two commits: the changelog gap I found while reviewing the plan, and the first item of plan section **B (experiment management)** — run comparison.

## Run comparison (`d6632d9`)

The detail panel already had a "compare against" picker, but it only fed the config diff — the charts stayed single-run. So answering *"which of these two experiments actually learned better?"* meant eyeballing two screens and remembering numbers.

Now that picker governs both tabs. Selecting a run fetches its metrics and overlays them on the loss / LR / memory charts:

- **No contract change.** The second series comes from the already-frozen `GET /train/jobs/{id}/metrics` with a different run id — `docs/api.md` and `backend/` are untouched.
- **Distinct in colour *and* stroke** (amber + `6 4` dash), so the pairing survives greyscale and colour-blind viewing. The legend names each series with its run, and a `Solid: … · Dashed: …` line sits above the charts.
- **Aligned by step**: a 200-iter run simply stops earlier than a 300-iter one — nothing is truncated or resampled to force a match.
- **Only the comparison's train loss** is overlaid: four curves on one loss axis is unreadable, and `val` only exists when a val split is configured, so a val overlay would silently vanish for many pairs. The base run keeps both its curves.
- **Degraded states**: a comparison run still loading, with no metrics (e.g. a failed run), or whose fetch errors, collapses to a small note above *untouched* base charts — a failed second fetch never blanks the panel.

### Verified live, not just in tests

Seeded two completed GRPO runs (lr 1e-5 / 200 iters vs lr 5e-5 / 300 iters) with realistic curves, served a real build, and drove the UI with Playwright:

- 4 line paths render; exactly the two comparison series carry `stroke="var(--color-compare)"` + `stroke-dasharray="6 4"`
- the x-axis extends to 300 while the base series correctly ends at 200
- legend reads `Train loss · grpo-lr1e-5` / `Train loss · grpo-lr5e-5` / `Val loss · grpo-lr1e-5`
- the faster-learning run is immediately obvious from the two curves — which is the entire point of the feature

## Changelog catch-up (`83b97f8`)

Several merged PRs never got entries, and the release workflow generates notes straight from this file: `column_map` import mapping (#71), the GGUF preflight dependency gate (#69), tall-modal scrolling (#73), the load-sensitive cancel tests (#72), and the dependency/dependabot work (#57–#66, #76). Plus an entry for the comparison feature above.

## Verification

- `make test`: backend **536**, frontend **291** (+16) — all green
- `make lint` clean; `make build` green; en/tr i18n key parity holds across all namespaces
- One test-infra note from the implementation: the chart tests' shared `getBoundingClientRect` stub now returns 24px for the legend wrapper instead of a uniform 300px. With the old stub recharts subtracted a 300px legend from a 300px plot and drew **zero** curves in jsdom, so stroke/dash could never be asserted. Existing test bodies and assertions are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UEysgYYG512HSnoKf5cgm